### PR TITLE
Update html-quiz.md

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1068,7 +1068,7 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr): The HT
 - [ ] It will display nothing unless the **poster** attribute is set.
 - [ ] It will display a black window unless the **poster** attribute is set.
 
-### Q64. What is the correct way to describe an empty element?
+#### Q64. What is the correct way to describe an empty element?
 - [ ] It has opening and closing tags but no child content.
 - [ ] It display nothing on a website.
 - [x] It has no child content and no closing tag.

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1067,3 +1067,9 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr): The HT
 - [x] It will display the first frame of the video, unless the **poster** attribute is set.
 - [ ] It will display nothing unless the **poster** attribute is set.
 - [ ] It will display a black window unless the **poster** attribute is set.
+
+### Q64. What is the correct way to describe an empty element?
+- [ ] It has opening and closing tags but no child content.
+- [ ] It display nothing on a website.
+- [x] It has no child content and no closing tag.
+- [ ] It has child content but no cloding tag.

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1068,8 +1068,12 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr): The HT
 - [ ] It will display nothing unless the **poster** attribute is set.
 - [ ] It will display a black window unless the **poster** attribute is set.
 
+[Reference (w3schools)](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_video)
+
 #### Q64. What is the correct way to describe an empty element?
 - [ ] It has opening and closing tags but no child content.
 - [ ] It display nothing on a website.
 - [x] It has no child content and no closing tag.
 - [ ] It has child content but no cloding tag.
+
+[Reference (MDN Web Docs)](https://developer.mozilla.org/en-US/docs/Glossary/Empty_element)

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1060,3 +1060,10 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr): The HT
 - [x] `<quote>`
 - [ ] `<blockquote>`
 - [ ] `<notation>`
+
+#### Q63. How will a video look displayed on a fully loaded webpage if the `<video>` tag is used and the **autoplay** attribute is not set?
+
+- [ ] It will display a random frame from a video, unless the **poster** attribute is set.
+- [x] It will display the first frame of the video, unless the **poster** attribute is set.
+- [ ] It will display nothing unless the **poster** attribute is set.
+- [ ] It will display a black window unless the **poster** attribute is set.


### PR DESCRIPTION
Add 2 questions about `<video>` tag and empty element.
Ref: 
[Screenshoot Q63](https://res.cloudinary.com/retr00exe/image/upload/v1613062060/Screenshot_951_harncv.png)
[Screenshoot Q64](https://res.cloudinary.com/retr00exe/image/upload/v1613062060/Screenshot_952_m2yvko.png)

I also answer both the question, here's some proof from the HTML documentation, CMIIW
[Answer Q63 (w3schools)](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_video)
[Answer Q64 (MDN Web Docs)](https://developer.mozilla.org/en-US/docs/Glossary/Empty_element)