### PR TITLE
fixed maven wrong heading q35

### DIFF
--- a/java/java-quiz.md
+++ b/java/java-quiz.md
@@ -1036,7 +1036,7 @@ groucyButton.addActionListener(new ActionListener() {
 - [ ] There is no way to force an object to be garbage collected
 [Reference](https://www.baeldung.com/java-hashcode)
 
-### Q72. Java programmers commonly use design patterns. Some examples are the ______, which helps create instances of a class, the ______, which ensures that only one instance of a class can be created; and the ______, which allows for a group of algorithms to be interchangeable.
+#### Q72. Java programmers commonly use design patterns. Some examples are the ______, which helps create instances of a class, the ______, which ensures that only one instance of a class can be created; and the ______, which allows for a group of algorithms to be interchangeable.
 - [x] static factory method; singleton; strategy pattern
 - [ ] strategy pattern; static factory method; singleton
 - [ ] creation pattern; singleton; prototype pattern

--- a/maven/maven-quiz.md
+++ b/maven/maven-quiz.md
@@ -217,7 +217,7 @@ mvn install
 - [ ] dependencies
 - [ ] distribution management
 
-### Q35. What does the mvn clean command do?
+#### Q35. What does the mvn clean command do?
 - [x] It removes the target directory
 - [ ] It updates the version of the plugins defned in the POM file.
 - [ ] It removes unused dependencies in your project

--- a/oop/object-oriented-programming-quiz.md
+++ b/oop/object-oriented-programming-quiz.md
@@ -176,7 +176,7 @@
  - [ ] a set of variables that can change over time
  - [ ] a procedure associated with data and behaviour
 
-### Q28. A mobile phone is made up of components such as a motherboard, camera, and sensors. The motherboard represents all the functions of a phone, the display shows the display only, and the phone is represented as a whole. Which of the following has the highest level of abstraction?
+#### Q28. A mobile phone is made up of components such as a motherboard, camera, and sensors. The motherboard represents all the functions of a phone, the display shows the display only, and the phone is represented as a whole. Which of the following has the highest level of abstraction?
  - [ ] camera
  - [ ] display
  - [ ] motherboard


### PR DESCRIPTION
Fixed maven Q35 wrong heading format

The heading of Q35 should level 4 `####`  , not level 3 `###`