### PR TITLE
Corrected wrong answer on Q44

### DIFF
--- a/bash/bash-quiz.md
+++ b/bash/bash-quiz.md
@@ -445,9 +445,9 @@ mysql < file.sql > out.txt
 - [ ] cp history
 
 #### Q44. In order to write a script that iterates through the files in a directory, which of the following could you use?
-- [ ] `bash for i in $(ls); do ... done`
+- [x] `bash for i in $(ls); do ... done`
 - [ ] `bash for $(ls); do ... done`
-- [x] `bash for i in $ls; do ... done`
+- [ ] `bash for i in $ls; do ... done`
 - [ ] `bash for $ls; do ... done`
 
 #### Q45 When executing a command and passing the output of that command to another command, which character allows you to chain these commands together?


### PR DESCRIPTION
Actually, there is an error on every line because of the "bash" at the beggining, but that seems just a mistake.
The proper bash syntax would be: for i in $(ls); do ... ; done