### PR TITLE
Fixed wrong answer to Q28

### DIFF
--- a/linux/linux-assesment.md
+++ b/linux/linux-assesment.md
@@ -208,8 +208,8 @@ echo \$myNumber | sed -e 's/^[[:digit:]][[:digit:]][[:digit:]]/(&)/g'
 #### Q28. Why is the passwd command able to modify the /etc/passwd file?
 
 - [ ] The kernel identifies it as one of the names of extended commands.
-- [x] It has the same name as the file it modifies.
-- [ ] It has the SUID permission mode and is owned by root.
+- [ ] It has the same name as the file it modifies.
+- [x] It has the SUID permission mode and is owned by root.
 - [ ] It is a system administration command.
 
 #### Q29. When a user deletes a file using the rm command, Linux will **\_**.


### PR DESCRIPTION
This behaviour is controlled by the SUID permission. You can see the SUID mode for passwd with the command below:

   ls -l $(whereis -b passwd | sed s,^.*:,,)

Here, you will see 'rws' for the owner, which is root. About the 's', the info pages for ls are helpful:

     ‘s’
          If the set-user-ID or set-group-ID bit and the corresponding
          executable bit are both set.

     ‘S’
          If the set-user-ID or set-group-ID bit is set but the
          corresponding executable bit is not set.