### PR TITLE
Removed confusing comment on bash-quiz.md Q39

### DIFF
--- a/bash/bash-quiz.md
+++ b/bash/bash-quiz.md
@@ -398,8 +398,6 @@ done
 ```bash
 ls Hello[[.vertical-line.]]World
 ```
-It's matches also `Hello[[.vertical-line.]]World` file but if we have this and `Hello|World` file will always be matched last one
-
 - [ ] `Nothing, this is an invalid file glob.`
 - [ ] `Hello.vertical-line.World`
 - [ ] `Hello[[.vertical-line.]]World`


### PR DESCRIPTION
I haven't replaced the comment, but maybe it deserves some better insight.

This is a file glob, or pathname expansion. It matches `Hello|World` if it exists. If not, and the `Hello[[.vertical-line.]]World` does exist, it will list it as well, although there's no "matching" involved. In other words, there were no files matching the pattern. The question is about file globs, and it even comes with a clue in the first option.

This behaviour of the patterns being used as literal strings when there are no matching files is controlled by some shell options, like nullglob.

You can find out more with "man bash" under EXPANSION/Pathname Expansion.