### PR TITLE
Fixed Q31 in Linux

### DIFF
--- a/linux/linux-assesment.md
+++ b/linux/linux-assesment.md
@@ -229,8 +229,8 @@ echo \$myNumber | sed -e 's/^[[:digit:]][[:digit:]][[:digit:]]/(&)/g'
 #### Q31. What is one major difference between brace expansion and globs?
 
 - [ ] Globs create a list; brace expansion matches pattern.
-- [x] Brace expansion requires files to exist; globs do not.
-- [ ] Brace expansion creates a list; globs mart the list of pathnames.
+- [ ] Brace expansion requires files to exist; globs do not.
+- [x] Brace expansion creates a list; globs mart the list of pathnames.
 - [ ] Globs get processes first and brace expansion later.
 
 #### Q32. To remove all ACLs from a directory , use setfacl with which options?


### PR DESCRIPTION
Answer said that brace expansion requires files to exist.
You can test this in a shell by typing `echo number{1,2}`. Parameters expand to `number1` and `number2` always. Brace expansion creates a list.
Now try with globs and type `echo unreal*file`. If the file doesn't exist, and nullglob is not set, then it will remain the same. If there is at least one file matching the pattern, it will expand to the list of matching pathnames.