### PR TITLE
Update android-quiz.md

### DIFF
--- a/android/android-quiz.md
+++ b/android/android-quiz.md
@@ -197,6 +197,8 @@
 - [x] getDefaultSharedPreferances(this).getString(EMAIL,"")
 - [ ] getPreferances(this).getString(EMAIL,null)
 
+**Explanation:** In Method "getDefaultSharedPrefarances(this).getString()" Second parameter is passed so that it can be returned, in case key doesn't exist. So we need to pass an empty string to be returned in case key doesn't exist.
+
 #### Q20. Why is it problematic to define sizes using pixels on Android?
 - [ ] Although screen pixel density vary,this does not impact the use of pixels to define sizes.
 - [ ] Large devices always have more pixels so your UI elements will be effected if you define them with pixels.
@@ -523,6 +525,7 @@ buildTypes {
 		</intent-filter>
 	</activity>
 ```
+**Explanation:** Intent filters are used to make activities accessible to other apps using intents. So we have to choose option which have no intent filter to make sure it is not accessible by intent
 
 #### Q38. To preserve on-device memory, how might you determine that the user's device has limited storage capabilities?
 - [x] Use the `ActivityManager.isLowRamDevice()` method to find out whether a device defines itself as "low RAM."

--- a/android/android-quiz.md
+++ b/android/android-quiz.md
@@ -193,8 +193,8 @@
 
 #### Q19. How would you retrieve the value of a user's email from SharedPreferences while ensuring that the returned value is not null?
 - [ ] getPreferances(this).getString(Email,"")
-- [x] getDefaultSharedPrefarances(this).getString(EMAIL,null)
-- [ ] getDefaultSharedPreferances(this).getString(EMAIL,"")
+- [ ] getDefaultSharedPrefarances(this).getString(EMAIL,null)
+- [x] getDefaultSharedPreferances(this).getString(EMAIL,"")
 - [ ] getPreferances(this).getString(EMAIL,null)
 
 #### Q20. Why is it problematic to define sizes using pixels on Android?
@@ -494,11 +494,11 @@ buildTypes {
 - [x] main
 
 #### Q37. Which definition will prevent other apps from accessing your `Activity` class via an `intent`?
-- [ ]
+- [x]
 ```xml
 	<activity android:name=".ExampleActivity" />
 ```
-- [x]
+- [ ]
 ```xml
 	<activity android:name=".ExampleActivity">
 		<intent-filter>


### PR DESCRIPTION
19. In method "getDefaultSharedPrefarances(this).getString()" Second parameter is passed so that it can be returned, in case key doesn't exist. If we pass null as second parameter, then it will return null in case of null. Which we were trying to avoid

37. Intent filters are used to make activities accessible to other apps using intents. So we have to choose option which have no intent filter to make sure it is not accessible by intent