### PR TITLE
Update python-quiz.md

### DIFF
--- a/python/python-quiz.md
+++ b/python/python-quiz.md
@@ -1018,3 +1018,37 @@ Updated version of Question 14.
 - [ ] when you want to run code in one file while code in another file is also running
 - [x] when you want some code to continue running as long as some condition is true
 - [ ] when you need to run two or more chunks of code at once within the same file
+
+#### Q85. What is the correct syntax for defining an `__init__()` method that sets instance-specific attributes upon creation of a new class instance?
+
+- [ ]
+
+```python
+def __init__(self, attr1, attr2):
+    attr1 = attr1
+    attr2 = attr2
+```
+
+- [ ]
+
+```python
+def __init__(attr1, attr2):
+    attr1 = attr1
+    attr2 = attr2
+```
+
+- [x]
+
+```python
+def __init__(self, attr1, attr2):
+    self.attr1 = attr1
+    self.attr2 = attr2
+```
+
+- [ ]
+
+```python
+def __init__(attr1, attr2):
+    self.attr1 = attr1
+    self.attr2 = attr2
+```

--- a/python/python-quiz.md
+++ b/python/python-quiz.md
@@ -1052,3 +1052,5 @@ def __init__(attr1, attr2):
     self.attr1 = attr1
     self.attr2 = attr2
 ```
+
+**Explanation**: When instantiating a new object from a given class, the `__init__()` method will take both `attr1` and `attr2`, and set its values to their corresponding object attribute, that's why the need of using `self.attr1 = attr1` instead of `attr1 = attr1`.


### PR DESCRIPTION
Added Q85.
When instantiating a new object from a given class, the `__init__()` method will take both `attr1` and `attr2`, and set its values to their corresponding object attribute, that's why the need of using `self.attr1 = attr1` instead of `attr1 = attr1`.