### PR TITLE
Answer Q48 and add W3Schools source/explanation

### DIFF
--- a/front-end-development/front-end-development-quiz.md
+++ b/front-end-development/front-end-development-quiz.md
@@ -460,8 +460,13 @@ console.log(currencies);
 
 - [ ] Apply `float: left` to the second paragraph.
 - [ ] Apply `clear: right` to the floated item.
-- [ ] Apply `clear: left` to the second paragraph.
+- [x] Apply `clear: left` to the second paragraph.
 - [ ] Apply `clear: left` to the floated item.
+
+[Source: W3Schools](https://www.w3schools.com/css/css_float_clear.asp)
+
+**clear: left;**
+`When we use the float property, and we want the next element below (not on right or left), we will have to use the clear property. When clearing floats, you should match the clear to the float: If an element is floated to the left, then you should clear to the left. Your floated element will continue to float, but the cleared element will appear below it on the web page.`
 
 #### Q49. Which choice is not a result of invoking strict mode in JavaScript?
 


### PR DESCRIPTION
When you have a float property on an element and you want the next element to be below it, the clear property has to be used, matching the clear property to the float property. So if the image had a float: right; then the next element should have a matching clear: right;
<img width="1016" alt="Screen Shot 2021-08-28 at 7 59 29 PM" src="https://user-images.githubusercontent.com/83188832/131233962-4e5d4b05-4687-43e0-b633-e5b7a8cb0a17.png">
