### PR TITLE
Add Adobe Illustrator questions

### DIFF
--- a/adobe-illustrator/adobe-illustrator-quiz.md
+++ b/adobe-illustrator/adobe-illustrator-quiz.md
@@ -541,12 +541,18 @@
 - [x] Turn off the **Print** option for the layer.
 - [ ] Lock the layer.
 
+**Explanation:**
+From Adobe Help Center: [Make artwork nonprintable](https://helpx.adobe.com/illustrator/using/setting-documents-printing.html)
+
 #### Q74. If you had to send a file to a colleague, how could you collect everything needed to work on it, including any non-Adobe fonts and linked images?
 
 - [ ] Select **Select All** and then **Save Selection**.
 - [ ] Use the **Save as Template** command.
 - [x] Use the **Package** command.
 - [ ] Select **Select All** and then click the **Add Content** button in the **Libraries** panel.
+
+**Explanation:**
+From Adobe Help Center: [Share artwork](https://helpx.adobe.com/illustrator/how-to/sharing-basics.html)
 
 #### Q75. When working with a two-point perspective grid, which setting in the **Define Perspective Grid** dialog box do you use to change the size of grid cells so you can draw and move objects with more precision?
 

--- a/adobe-illustrator/adobe-illustrator-quiz.md
+++ b/adobe-illustrator/adobe-illustrator-quiz.md
@@ -533,3 +533,24 @@
 - [x] Blank areas may be visible at the edges of the print.
 - [ ] Areas of 100% black may print lighter than expected.
 - [ ] Blank areas may be visible where two inks are printed adjacent to each other.
+
+#### Q73. How can you ensure that objects on a specific layer remain visible on screen in Illustrator but never appear when the file is printed?
+
+- [ ] Make a clipping mask with the layer selected.
+- [ ] Drag the layer to the bottom of the **Layers** panel.
+- [x] Turn off the **Print** option for the layer.
+- [ ] Lock the layer.
+
+#### Q74. If you had to send a file to a colleague, how could you collect everything needed to work on it, including any non-Adobe fonts and linked images?
+
+- [ ] Select **Select All** and then **Save Selection**.
+- [ ] Use the **Save as Template** command.
+- [x] Use the **Package** command.
+- [ ] Select **Select All** and then click the **Add Content** button in the **Libraries** panel.
+
+#### Q75. When working with a two-point perspective grid, which setting in the **Define Perspective Grid** dialog box do you use to change the size of grid cells so you can draw and move objects with more precision?
+
+- [ ] Scale
+- [ ] Viewing Distance
+- [ ] Viewing Angle
+- [ ] Gridling every


### PR DESCRIPTION

**Q73 Explanation:** 
From Adobe Help Center: [Make artwork nonprintable](https://helpx.adobe.com/illustrator/using/setting-documents-printing.html)

> To prevent artwork from printing, but not from showing on the artboard or exporting, double-click a layer name in the Layers panel. In the Layer Options dialog box, deselect the Print option, and click OK. The layer name changes to italics in the Layers panel.

**Q74 Explanation:** 
From Adobe Help Center: [Share artwork](https://helpx.adobe.com/illustrator/how-to/sharing-basics.html)