### PR TITLE
fix Q64 & Q65

### DIFF
--- a/react/reactjs-quiz.md
+++ b/react/reactjs-quiz.md
@@ -678,7 +678,7 @@ useEffect(() => {
 <Route path="/:id" />
 ```
 
-- [x]
+- [x] A
 
 ```javascript
 <Route path="/:id">
@@ -687,19 +687,19 @@ useEffect(() => {
 </Route>
 ```
 
-- [ ]
+- [ ] B
 
 ```javascript
 <Route path="/tid" about={Component} />
 ```
 
-- [ ]
+- [ ] C
 
 ```javascript
 <Route path="/:id" route={About} />
 ```
 
-- [ ]
+- [ ] D
 
 ```javascript
 <Route>
@@ -713,32 +713,42 @@ useEffect(() => {
 const Greeting ({ name }) > <h1>Hello {name}!</h1>;
 ```
 
-- [ ]
+- [ ] A
 
 ```javascript
 class Greeting extends React.Component {
   constructor() {
-    return <h1>Hello (this.props.name)!</h1>;
+    return <h1>Hello {this.props.name}!</h1>;
   }
 }
 ```
 
-- [x]
+- [ ] B
 
 ```javascript
-    class Greeting extends React.Component { <h1>Hello {this.props.name}!</h1>; }
+class Greeting extends React.Component { 
+  <h1>Hello {this.props.name}!</h1>; 
+}
 ```
 
-- [ ]
+- [x] C
 
 ```javascript
-   class Greeting extends React.Component { return <h1>Hello (this.props.name) 1</h1>; }
+class Greeting extends React.Component { 
+  render() {
+      return <h1>Hello {this.props.name}!</h1>; 
+  }
+}
 ```
 
-- [ ]
+- [ ] D
 
 ```javascript
-class Greeting extends React.Component ( render({ name }) {return <h1>Hello (name)} !</h1>;})
+class Greeting extends React.Component {
+  render({ name }) {
+    return <h1>Hello {name}!</h1>;
+  }
+}
 ```
 
 #### Q66. Give the code below, what does the second argument that is sent to the render function describe?


### PR DESCRIPTION
* add letters after markdown checkboxes  e.g. `-  [  ] A` so that checkboxes get visually displayed (without any text behind no checkboxes get rendered)
* fix Q65 examples (wrong syntax, incomplete code)