### PR TITLE
Update rest-api-quiz.md

### DIFF
--- a/rest-api/rest-api-quiz.md
+++ b/rest-api/rest-api-quiz.md
@@ -181,7 +181,8 @@
 - [ ] `client-only`
 - [ ] `restricted`
 - [x] `private`
-      [reference](https://www.digitalocean.com/community/tutorials/web-caching-basics-terminology-http-headers-and-caching-strategies)
+ 
+[reference](https://www.digitalocean.com/community/tutorials/web-caching-basics-terminology-http-headers-and-caching-strategies)
 
 #### Q25. Which OAuth grant type can support a refresh token?
 
@@ -189,6 +190,8 @@
 - [ ] `Client Credentials Grant`
 - [ ] `Implicit Grant`
 - [ ] `Authentication Grant`
+
+[Reference:](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3)
 
 #### Q26. Using OAuth, what scope would you request for write access to the API?
 

--- a/rest-api/rest-api-quiz.md
+++ b/rest-api/rest-api-quiz.md
@@ -185,8 +185,8 @@
 
 #### Q25. Which OAuth grant type can support a refresh token?
 
-- [ ] `Authorization Code Grant`
-- [x] `Client Credentials Grant`
+- [x] `Authorization Code Grant`
+- [ ] `Client Credentials Grant`
 - [ ] `Implicit Grant`
 - [ ] `Authentication Grant`
 


### PR DESCRIPTION
#### Q25. Which OAuth grant type can support a refresh token?
The answer is Authorization code grant that supports refresh tokens optionally. Reference: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3