### PR TITLE
<#2368> Adding valid answers to Q72 and Q75 with reference link and also fixing typos for Q72

### DIFF
--- a/aws/aws-quiz.md
+++ b/aws/aws-quiz.md
@@ -662,15 +662,17 @@ aws ecs create-service \
  --service-name rest-api \
  --task-definition rest-api:1 \
  --desired-count 2 \
- --launch-type "FARGET" \
+ --launch-type "FARGATE" \
  --network-configuration \
  "awsvpcConfiguration={subnets=[subnet-0b29129ab],securityGroups=[sg-0b29129ab]}"
 ```
 
 - [ ] changes the security groups of the running **rest-api** task
-- [ ] creates a cluster called **production** and launches two containers into Farget with the **rest-api** task definition
-- [ ] launches two containers onto Farget into the existing **production** cluster using the **rest-api** task definition
+- [x] creates a cluster called **production** and launches two containers into FARGATE with the **rest-api** task definition
+- [ ] launches two containers onto FARGATE into the existing **production** cluster using the **rest-api** task definition
 - [ ] creates a service definition for the **rest-api** task; put two containers on the production cluster when launched **ecs-cli** up command
+
+[Reference] (https://docs.aws.amazon.com/cli/latest/reference/ecs/create-service.html#examples)
 
 #### Q73. You want to make your public API quickly accessible from all regions. What is the best way to do this?
 
@@ -690,8 +692,10 @@ aws ecs create-service \
 
 - [ ] Use a Classic Load Balancer, not Application Load Balancer.
 - [ ] Application Load Balancer does not preserve the original source IP address. The analytics software needs to be configured to look at the 'X-Forwarded-For' HTTP request header for the correct source IP address.
-- [ ] Application Load Balencer has to be configured to retain the source IP address of the traffic it is forwarding. Create a policy that enables ProxyProtocol support and attach it to the ALB using the AWS CLI.
+- [x] Application Load Balencer has to be configured to retain the source IP address of the traffic it is forwarding. Create a policy that enables ProxyProtocol support and attach it to the ALB using the AWS CLI.
 - [ ] Configure the web server EC2 instances to only have private IP addresses. The public IP addresses of the instances are being recorded into the web server logs, bug only ALB should have a public interface and it will route traffic to instances via the private interface.
+
+[Reference] (https://aws.amazon.com/premiumsupport/knowledge-center/elb-route-requests-with-source-ip-alb/)
 
 #### Q76. What is `not` a default user of a common Linux instance launched from an AMI?
 


### PR DESCRIPTION

This PR contains valid answers for Q72 and Q75 with reference link and also fixing typos for Q72.
This issue was created by @hectcastro  - https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/pull/2368