### PR TITLE
Answer added to another two questions

### DIFF
--- a/cybersecurity/cybersecurity-quiz.md
+++ b/cybersecurity/cybersecurity-quiz.md
@@ -229,7 +229,7 @@
 #### Q31. An attacker has discovered that they can deduce a sensitive piece of confidential information by analyzing multiple pieces of less sensitive public data. What type of security issue exists?
 
 - [ ] cross-origin resource sharing
-- [ ] inference
+- [x] inference
 - [ ] SQL injection
 - [ ] aggregation
 


### PR DESCRIPTION
Answer explanation: All answers are correct in the sense that they can be utilized to detect intrusion. However unlike the other three answers the goal of a packet sniffer isn’t specifically to detect intrusion and therefore it is the “least” likely to alert you of such event. That is not to say that it won’t alert you as in the case of certain deployments of HoneyPots, where there isn’t supposed to be any incoming traffic can be set up to alert the owner since any traffic should be deemed suspicious.