### PR TITLE
Added response to outlook question

### DIFF
--- a/microsoft-outlook/microsoft-outlook-quiz.md
+++ b/microsoft-outlook/microsoft-outlook-quiz.md
@@ -80,7 +80,7 @@ C. Read receipts are expensive, so some organizations turn them off.
 
 #### Q11. What does Outlook automatically point out to you when you are invited to a meeting?
 
-- [ ] if your attendance is mandatory
+- [x] if your attendance is mandatory
 - [ ] ifthe meeting is high or low priority
 - [ ] the amount of time you have between this meeting and your next event
 - [ ] if the meeting is adjacent to another event in your calendar


### PR DESCRIPTION
I've worked with outlook for 20+years. When a meeting invite is created and sent to a user, it will either have you on "Required" line, or if you are not Required it will show "Optional"