### PR TITLE
Add more questions to the Go skill quiz with their corresponding answers

### DIFF
--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -234,3 +234,107 @@ Example on [Go Playground](https://play.golang.org/p/TXF_JBvThp6)
 - [ ] a lightweight thread for concurrent programming
 
 Reference: [Channels](https://tour.golang.org/concurrency/2)
+
+#### Q18. How can you make a file build only on Windows?
+
+- [ ] Check runtime.GOOS.
+- [ ] Add a // +build windows comment anywhere in the file.
+- [ ] Add a _ prefix to the file name.
+- [x] Add a // +build windows comment at the top of the file.
+
+Reference: [How to use conditional compilation with the go build tool, Oct 2013](https://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool)
+
+#### Q19. What is the correct way to pass this as a body of an HTTP POST request?
+
+```go
+data := "A group of Owls is called a parliament"
+```
+
+- [ ] resp, err := http.Post("https://httpbin.org/post", "text/plain", []byte(data))
+- [ ] resp, err := http.Post("https://httpbin.org/post", "text/plain", data)
+- [x] resp, err := http.Post("https://httpbin.org/post", "text/plain", strings.NewReader(data))
+- [ ] resp, err := http.Post("https://httpbin.org/post", "text/plain", &data)
+
+Reference: [net/http#Client.Post](https://pkg.go.dev/net/http#Client.Post)
+
+#### Q20. What should the idiomatic name be for an interface with a single method and the signature `Save() error`?
+
+- [ ] Saveable
+- [ ] SaveInterface
+- [ ] ISave
+- [x] Saver
+
+Reference: [Effective Go, Interface names](https://golang.org/doc/effective_go#interface-names)
+
+#### Q21. A `switch` statement _____ its own lexical block. Each `case` statement _____ an additional lexical block.
+
+- [ ] does not create; creates
+- [ ] does not create; does not create
+- [x] creates; creates
+- [ ] creates; does not create
+
+Reference: [Go Language Core technology (Volume one) 1.5-scope](https://topic.alibabacloud.com/a/go-language-core-technology-volume-one-15-font-colorredscopefont_1_38_30923325.html)
+
+Relevant excerpt from the article:
+
+> _The second if statement is nested inside the first, so a variable declared in the first if statement is visible to the second if statement. There are similar rules in switch: Each case has its own lexical block in addition to the conditional lexical block._
+
+#### Q22. What is the default case sensitivity of the JSON `Unmarshal` function?
+
+- [x] The default behavior is case insensitive, but it can be overridden.
+- [ ] Fields are matched case sensitive.
+- [ ] Fields are matched case insensitive.
+- [ ] The default behavior is case sensitive, but it can be overridden.
+
+Reference: [encoding/json#Unmarshal](https://pkg.go.dev/encoding/json#Unmarshal)
+
+Relevant excerpt from the article:
+
+> _To unmarshal JSON into a struct, Unmarshal matches incoming object keys to the keys used by Marshal (either the struct field name or its tag), preferring an exact match but also accepting a case-insensitive match. By default, object keys which don't have a corresponding struct field are ignored (see Decoder.DisallowUnknownFields for an alternative)._
+
+#### Q23. What is the difference between the `time` package’s `Time.Sub()` and `Time.Add()` methods?
+
+- [ ] Time.Add() is for performing addition while Time.Sub() is for nesting timestamps.
+- [ ] Time.Add() always returns a later time while time.Sub always returns an earlier time.
+- [x] They are opposites. Time.Add(x) is the equivalent of Time.Sub(-x).
+- [ ] Time.Add() accepts a Duration parameter and returns a Time while Time.Sub() accepts a Time parameter and returns a Duration.
+
+Reference: [time#Time.Add](https://pkg.go.dev/time#Time.Add)
+
+Reference: [time#Time.Sub](https://pkg.go.dev/time#Time.Sub)
+
+#### Q24. What is a risk of using multiple field tags in a single struct?
+
+- [ ] Every field must have all tags to compile.
+- [x] It tightly couples different layers of your application.
+- [ ] Any tags after the first are ignored.
+- [ ] Missing tags panic at runtime.
+
+Reference: [Example Code / b29r0fUD1cp](https://play.golang.org/p/b29r0fUD1cp)
+
+#### Q25. Where is the built-in recover method useful?
+
+- [ ] in the main function
+- [ ] immediately after a line that might panic
+- [x] inside a deferred function
+- [ ] at the beginning of a function that might panic
+
+Reference: [Example of Recover Function in Go (Golang)](https://golangbot.com/panic-and-recover/#recoveringfromapanic)
+
+Relevant excerpt from the article:
+
+> _Recover is useful only when called inside deferred functions. Executing a call to recover inside a deferred function stops the panicking sequence by restoring normal execution and retrieves the error message passed to the panic function call. If recover is called outside the deferred function, it will not stop a panicking sequence._
+
+#### Q26. Which choice does _not_ send output to standard error?
+
+- [x] println(message)
+- [ ] log.New(os.Stderr, "", 0).Println(message)
+- [ ] fmt.Errorf("%s\n", message)
+- [ ] fmt.Fprintln(os.Stderr, message)
+
+#### Q27. How can you tell Go to import a package from a different location?
+
+- [ ] Use a proxy.
+- [ ] Change the import path.
+- [x] Use a replace directive in go.mod.
+- [ ] Use a replace directory.


### PR DESCRIPTION
I obtained a skill badge with a combination of questions from [commit 792fff1](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/commit/792fff166cce5d75e97c4a022ec0f929d5a33709) (thanks @ruslanbes) and [commit 66a1dc9](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/commit/66a1dc93b93d429f9214c78e5e97c7972ad94f8c) (this pull-request). Although, I am not entirely sure if all the questions have the correct answer, but I did my best to verify them by doing my own research and also by asking questions in the Gophers Slack group: https://invite.slack.golangbridge.org/