### PR TITLE
Fixed <h1> tag formatting

### DIFF
--- a/react/reactjs-quiz.md
+++ b/react/reactjs-quiz.md
@@ -909,7 +909,7 @@ ReactDOM.createPortal(x, y);
 - [ ] the current state
 - [x] the DOM element that exists outside of the parent component
 
-#### Q79. Given this code, what will be printed in the <h1> tag?
+#### Q79. Given this code, what will be printed in the `<h1>` tag?
 
 ```javascript
 const MyComponent = ({ children }) => (


### PR DESCRIPTION
The `<h1>` tag in this question was rendering as an actual html tag, causing it to not appear and throw off the formatting of the rest of the question. I just put it in backticks to resolve this.