### PR TITLE
Add answer to Go quiz question

### DIFF
--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -480,4 +480,4 @@ fmt.Println("%f\n", price)
 - [ ] Set GOOS to **arm64** and GOARCH to **darwin**.
 - [ ] Set GOOS to **osx** and GOARCH to **arm64**.
 - [ ] Set GOOS to **arm64** and GOARCH to **osx**.
-- [ ] Set GOOS to **darwin** and GOARCH to **arm64**.
+- [x] Set GOOS to **darwin** and GOARCH to **arm64**.

--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -481,3 +481,5 @@ fmt.Println("%f\n", price)
 - [ ] Set GOOS to **osx** and GOARCH to **arm64**.
 - [ ] Set GOOS to **arm64** and GOARCH to **osx**.
 - [x] Set GOOS to **darwin** and GOARCH to **arm64**.
+
+(documentation)[https://pkg.go.dev/cmd/go#hdr-Build_constraints]

--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -482,4 +482,4 @@ fmt.Println("%f\n", price)
 - [ ] Set GOOS to **arm64** and GOARCH to **osx**.
 - [x] Set GOOS to **darwin** and GOARCH to **arm64**.
 
-(documentation)[https://pkg.go.dev/cmd/go#hdr-Build_constraints]
+[documentation](https://pkg.go.dev/cmd/go#hdr-Build_constraints)


### PR DESCRIPTION
Added the answer to currently Q41 in the Go quiz. 
- [x] Set GOOS to **darwin** and GOARCH to **arm64**.

According to the documentation https://pkg.go.dev/cmd/go#hdr-Build_constraints and testing it myself I was able to compile with `GOOS=darwnin` and `GOARCH=arm64`