### PR TITLE
Git fix Q103

### DIFF
--- a/git/git-quiz.md
+++ b/git/git-quiz.md
@@ -860,10 +860,10 @@ Changes not staged for commit:
 
 #### Q103. How would you display a histogram showing inserts, deletion, and modifications per file for a specific commit along with its general commit information?
 
-- [ ] Use git stat.
-- [ ] Use git debug --prettyprint.
+- [ ] Use `git stat`.
+- [ ] Use `git debug --prettyprint`.
 - [ ] Query the remote repository with the commit hash.
-- [x] Use git show <commit> --stat.
+- [x] Use `git show <commit> --stat`.
 
 [Reference](https://git-scm.com/docs/git-show#Documentation/git-show.txt---statltwidthgtltname-widthgtltcountgt)
 


### PR DESCRIPTION
markdown escape was missing