### PR TITLE
Add correct answer and image to Python Q132

### DIFF
--- a/python/python-quiz.md
+++ b/python/python-quiz.md
@@ -1781,10 +1781,10 @@ for x in range(1,len(characters)):
 
 #### Q132. Jaccard Similarity is a formula that tells you how similar two sets are. It is defined as the cardinality of the intersection divided by the cardinality of the union. Which choice is an accurate implementation in Python?
 
-![Q132](images/Q132.png)
+<img src="http://www.sciweavers.org/tex2img.php?eq=J%28A%2CB%29%20%3D%20%7B%7B%7CA%20%5Ccap%20B%7C%7D%5Cover%7B%7CA%20%5Ccup%20B%7C%7D%7D&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0" align="center" border="0" alt="J(A,B) = {{|A \cap B|}\over{|A \cup B|}}" width="131" height="46" />
 
 - [ ] `def jaccard(a, b): return len (a | b) / len (a & b)`
-- [ ] `def jaccard(a, b): return len (a & b) / len (a | b)`
+- [x] `def jaccard(a, b): return len (a & b) / len (a | b)`
 - [ ] `def jaccard(a, b): return len (a && b) / len (a || b)`
 - [ ] `def jaccard(a, b): return a.intersection(b) / a.union(b)`
 


### PR DESCRIPTION
Added _def jaccard(a, b): return len (a & b) / len (a | b)_ as the correct answer, as discussed in #3389.

Removed the link to https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/blob/master/python/images/Q132.png, since it did not point to any existing resource yet and added the mathematical expression of the Jaccard Similarity written in LaTeX. Since the GitHub markdown does not support this natively, we add it as an image source from http://www.sciweavers.org/free-online-latex-equation-editor.