### PR TITLE
PHP Q1 answer depent on the PHP version

### DIFF
--- a/php/php-quiz.md
+++ b/php/php-quiz.md
@@ -10,6 +10,7 @@
 - [x] 0
 
 **_Both sides of the "spaceship" are equal, so the answer is 0. PHP will convert '76 trombones' to 76 in this context, as the string starts with '76'. Try it!_**
+**_For php 8.0 and forward the answer is [x] -1, for previous versions the answer is [x] 0._**
 
 ##### Q2. Which is the most secure way to avoid storing a password in clear text in database?
 


### PR DESCRIPTION
I don't know the PHP version used in the quiz, but I run the code in PHP 8.* and PHP 7.* and the result is different.

PHP 8.*
```
php > var_dump(76 <=> '76 a');
php shell code:1:
int(-1)
```

PHP 7.*
```
php > var_dump(76 <=> '76 a');
php shell code:1:
int(0)
```