### PR TITLE
Preserve `--` formatting in HTML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+# Build settings
+markdown: kramdown
+
+# Preserve double and triple dashes
+kramdown:
+  typographic_symbols:
+    mdash: "---"
+    ndash: "--"


### PR DESCRIPTION
By default the Jekyll renderer (Kramdown) renders `--` as an "n-dash"

Problem : text like "git --version" which isn't escaped between backticks get transformed into "git –version" (long dash instead of two dashes). This produces incorrect results and makes it harder to search in the page - see for example https://ebazhanov.github.io/linkedin-skill-assessments-quizzes/git/git-quiz.html vs the original [git-quiz.md](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/blob/master/git/git-quiz.md).

This simple PR fixes this, preserving `--` and `---` ; see results at https://ozh.github.io/linkedin-skill-assessments-quizzes/git/git-quiz.html