### PR TITLE
HTML cleanup

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -421,12 +421,12 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 </table>
 ```
 
-#### Q26. What is the `<hr>`tag typically used for?
+#### Q26. What is the `<hr>`tag typically used for? / Alt.: What is the semantic meaning of the `<hr>` tag?
 
-- [ ] This tag is depreciated and should not be used.
+- [ ] This tag is depreciated (alt.: deprecated) and should not be used.
 - [x] It designates a topic shift within a section at the paragraph level.
 - [ ] It draws a horizontal line.
-- [ ] It designates a shift of topic at the section level.
+- [ ] It designates a shift of topic at the section level. / Alt.: It designates a separation of sections within an `<article>`.
 
 This is a confusing question and there can be an arguments for both the second and the third options being correct.
 
@@ -996,13 +996,6 @@ This is a confusing question and there can be an arguments for both the second a
 - [ ] `<notation>`
 
 [Reference (w3schools)](https://www.w3schools.com/html/html_quotation_elements.asp)
-
-#### Q61. What is the semantic meaning of the `<hr>` tag?
-
-- [ ] It draws a horizontal line.
-- [ ] This tag is deprecated and should not be used.
-- [ ] It designates a separation of sections within an `<article>`.
-- [x] It designates a topic shift within a section at the paragraph level.
 
 #### Q62. How will a video look displayed on a fully loaded webpage if the `<video>` tag is used and the **autoplay** attribute is not set?
 

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -996,7 +996,7 @@ The html element represents the root of a document.
 
 [Reference (w3schools)](https://www.w3schools.com/html/html_quotation_elements.asp)
 
-#### Q62. How will a video look displayed on a fully loaded webpage if the `<video>` tag is used and the **autoplay** attribute is not set?
+#### Q61. How will a video look displayed on a fully loaded webpage if the `<video>` tag is used and the **autoplay** attribute is not set?
 
 - [ ] It will display a random frame from a video, unless the **poster** attribute is set.
 - [x] It will display the first frame of the video, unless the **poster** attribute is set.
@@ -1005,7 +1005,7 @@ The html element represents the root of a document.
 
 [Reference (w3schools)](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_video)
 
-#### Q63. What is the correct way to describe an empty element / Alt.: What is the correct way to describe an empty element, such as a line break tag?
+#### Q62. What is the correct way to describe an empty element / Alt.: What is the correct way to describe an empty element, such as a line break tag?
 
 - [ ] It has opening and closing tags but no child content.
 - [ ] It display nothing on a website.
@@ -1014,7 +1014,7 @@ The html element represents the root of a document.
 
 [Reference (MDN Web Docs)](https://developer.mozilla.org/en-US/docs/Glossary/Empty_element)
 
-#### Q64. What is the purpose of async in this code?
+#### Q63. What is the purpose of async in this code?
 
 `<script async src="myscript.js"></script>`
 
@@ -1023,7 +1023,7 @@ The html element represents the root of a document.
 - [x] It runs the script when the script is ready.
 - [ ] It pauses the parsing of HTML code while the script runs.
 
-#### Q65. What does this code do on a page you are visiting for the first time?
+#### Q64. What does this code do on a page you are visiting for the first time?
 
 `<audio autoplay loop src="sound.mp3" type="audio/mpeg"></audio>`
 
@@ -1035,14 +1035,14 @@ The html element represents the root of a document.
 References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio),
 [(MDN) autoplay](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide)
 
-#### Q66. What is the difference between the `<head>` and `<header>` tags?
+#### Q65. What is the difference between the `<head>` and `<header>` tags?
 
 - [ ] There is only one `<head>` tag per page, while there may be many `<header>` tags.
 - [ ] The `<head>` tag may contain CSS and Javascript links, while the `<header>` tag may contain headings and navigational links.
 - [x] all of these answers
 - [ ] The `<head>` tag contains meta information, while the `<header>` tag contains navigation, logos, and other page identifying content.
 
-#### Q67. In this code, what is the purpose of defer?
+#### Q66. In this code, what is the purpose of defer?
 
 `<script defer src="myscript.js"></script>`
 
@@ -1051,7 +1051,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 - [ ] It runs the script when the script is ready.
 - [ ] It pauses the parsing of HTML code while the script runs.
 
-#### Q68. The code below contains some errors. Which choice corrects all of the errors?
+#### Q67. The code below contains some errors. Which choice corrects all of the errors?
 
 ```html
 <table>
@@ -1113,7 +1113,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 </table>
 ```
 
-#### Q69. Given the file and directory structure shown here, what is the correct element to place in file profit.html to link to info.html?
+#### Q68. Given the file and directory structure shown here, what is the correct element to place in file profit.html to link to info.html?
 
 ![Image of footer](images/ss-7.png?raw=true)
 
@@ -1122,7 +1122,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 - [ ] `<a href="../../info.html">See Information </a>`
 - [ ] `<a href="info.html">See Information </a>`
 
-#### Q70. When should you use the `<article>` element?
+#### Q69. When should you use the `<article>` element?
 
 - [ ] For blog posts and other social media items
 - [ ] For the main content area of your website
@@ -1131,7 +1131,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 [Reference (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
 
-#### Q71. Which list comprises three empty elements?
+#### Q70. Which list comprises three empty elements?
 
 - [ ] A
 
@@ -1165,14 +1165,14 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 <source>
 ```
 
-#### Q72. Which snippet of HTML, when clicked, makes a phone call on a mobile device?
+#### Q71. Which snippet of HTML, when clicked, makes a phone call on a mobile device?
 
 - [x] `<a href="tel:802-555-1212">Call me</a>`
 - [ ] `<a href="phone">802-555-1212</a>`
 - [ ] `<a href="tel">802-555-1212</a>`
 - [ ] `<a href="phone:802-555-1212">Call me</a>`
 
-#### Q73. What is the purpose of the `class` attribute?
+#### Q72. What is the purpose of the `class` attribute?
 
 - [ ] Classes allow CSS to select specific elements on the page. You may list as many class names within the class attribute as you wish,
       separated by spaces.
@@ -1183,7 +1183,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 [Reference (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class)
 
-#### Q74. Which choice is not a legal type attribute for the `<input>` tag?
+#### Q73. Which choice is not a legal type attribute for the `<input>` tag?
 
 - [ ] `<input type="color">`
 - [ ] `<input type="tel">`
@@ -1192,7 +1192,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 [Reference (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input)
 
-#### Q75. What is the most semantic way to mark up this sentence so that "happy talk must die" is rendered as an inline quote?
+#### Q74. What is the most semantic way to mark up this sentence so that "happy talk must die" is rendered as an inline quote?
 
 As Steve Krug once said, happy talk must die.
 
@@ -1206,7 +1206,7 @@ As Steve Krug once said, happy talk must die.
 **`<q>` tag**
 `Most browsers will display q tags as inline elements with quotes`
 
-#### Q76. What is the most semantically accurate way to make up a main navigation bar, displayed in a horizontal direction?
+#### Q75. What is the most semantically accurate way to make up a main navigation bar, displayed in a horizontal direction?
 
 - [ ] A
 
@@ -1252,7 +1252,7 @@ As Steve Krug once said, happy talk must die.
   </nav>
 ```
 
-#### Q77. Which choice is the best way to mark up this layout?
+#### Q76. Which choice is the best way to mark up this layout?
 
 ![Image of footer](images/ss-8.png?raw=true)
 
@@ -1304,14 +1304,14 @@ As Steve Krug once said, happy talk must die.
 
 `The <address> tag defines the contact information for the author/owner of a document or an article. The contact information can be an email address, URL, physical address, phone number, social media handle, etc. The text in the <address> element usually renders in italic, and browsers will always add a line break before and after the <address> element.`
 
-#### Q78. What is the primary purpose of HTML?
+#### Q77. What is the primary purpose of HTML?
 
 - [x] HTML structures the webpage, identifying its elements such as paragraphs, headings, and lists.
 - [ ] HTML structures and provides a rudimentary look to webpages.
 - [ ] HTML is responsible for the structure, styling, and interactivity of webpages.
 - [ ] HTML is responsible for the structure and styling of webpages.
 
-#### Q80. For the HTML code below, when will "Sample Text" display to the browser?
+#### Q78. For the HTML code below, when will "Sample Text" display to the browser?
 
 ```html
 <noscript>Sample Text</noscript>
@@ -1324,7 +1324,7 @@ As Steve Krug once said, happy talk must die.
 
 [Reference (MDN)](https://www.w3schools.com/tags/tag_noscript.asp)
 
-#### Q81. How will this code render by default in most web browsers?
+#### Q79. How will this code render by default in most web browsers?
 
 ```html
 <details>
@@ -1342,14 +1342,14 @@ As Steve Krug once said, happy talk must die.
 - [ ] D
       ![D](images/Q84-4.jpg)
 
-#### Q83. What is the difference between the `<svg>` and `<canvas>`?
+#### Q80. What is the difference between the `<svg>` and `<canvas>`?
 
 - [x] `<svg>` produces vector graphics, while `<canvas>` produces raster graphics.
 - [ ] `<svg>` integrates with JavaScript, while `<canvas>` does not.
 - [ ] `<svg>` produces raster graphics, while `<canvas>` produces vector graphics.
 - [ ] `<svg>` cannot be used as a background image, while `<canvas>` can be used as a background
 
-#### Q84. What is the difference between the _readonly_ and _disabled_ attributes for the `<textarea>` element?
+#### Q81. What is the difference between the _readonly_ and _disabled_ attributes for the `<textarea>` element?
 
 - [x] _readonly_ allows clicking in the `<textarea>` element. _disabled_ prevents all interaction with the control.
 - [ ] _readonly_ is invalid attribute for `<textarea>`, while _disabled_ is a valid attribute.
@@ -1360,7 +1360,7 @@ As Steve Krug once said, happy talk must die.
 
 [Source: disabled](https://www.w3schools.com/tags/att_disabled.asp)
 
-#### Q85. In this code, what is _target_?
+#### Q82. In this code, what is _target_?
 
 `<a target="_blank">...</a>`
 
@@ -1369,7 +1369,7 @@ As Steve Krug once said, happy talk must die.
 - [ ] content
 - [ ] an element
 
-#### Q86. What is the correct way to add a submit URL to a `button` element?
+#### Q83. What is the correct way to add a submit URL to a `button` element?
 
 - [ ] A
 
@@ -1405,7 +1405,7 @@ As Steve Krug once said, happy talk must die.
 
 `formaction — The URL that processes the information submitted by the button. Overrides the action attribute of the button's form owner. Does nothing if there is no form owner.` [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formaction)
 
-#### Q87. Which is the best markup to produce this text?
+#### Q84. Which is the best markup to produce this text?
 
 `x<y&z>w`
 
@@ -1418,7 +1418,7 @@ As Steve Krug once said, happy talk must die.
 
 `It's too strange question because all of that methods doesn't work. The good method is &amp, &lt, &gt using.`
 
-#### Q88. What is wrong with this code snippet?
+#### Q85. What is wrong with this code snippet?
 
 ```html
 <label>Address:</label>
@@ -1430,35 +1430,35 @@ As Steve Krug once said, happy talk must die.
 - [ ] The `<label>` element is missing an **id** set to "address-input".
 - [x] The `<label>` element is missing a **for** attribute set to "address-input".
 
-#### Q89. What is the default method for form submission?
+#### Q86. What is the default method for form submission?
 
 - [x] GET
 - [ ] POST
 - [ ] PUT
 - [ ] SUBMIT
 
-#### Q90. Which is the most semantically correct markup for a side comment in small print?
+#### Q87. Which is the most semantically correct markup for a side comment in small print?
 
 - [x] `<p>` Get 10% discount `<small>`not valid in France`</small></p>`
 - [ ] `<p>` Get 10% discount `<!--not valid in France--> </p>`
 - [ ] `<p>` Get 10% discount `<comment>`not valid in France`</comment></p>`
 - [ ] `<p>` Get 10% discount `<aside>`not valid in France`</aside></p>`
 
-#### Q91. Which choice will produce the spanish word <i>canción</i>?
+#### Q88. Which choice will produce the spanish word <i>canción</i>?
 
 - [ ] `<p lang="es">canción</p>`
 - [x] `<p lang="es">canci&oacuten</p>`
 - [ ] `<p lang="es">cancio'n</p>`
 - [ ] `<p lang="es">canci'on</p>`
 
-#### Q92. What is the purpose of `<caption>`?
+#### Q89. What is the purpose of `<caption>`?
 
 - [ ] `<caption>` provides captions for `<audio>`,`<video>`,`<img>`, and `<table>`.
 - [x] `<caption>` provides captions to `<table>`.
 - [ ] `<caption>` provides captions for `<audio>`, `<video>`, and `<table>`.
 - [ ] `<caption>` provides captions for `<img>`, `<audio>`, and `<video>`.
 
-#### Q93. The value attribute is associated with which set of tags ?
+#### Q90. The value attribute is associated with which set of tags ?
 
 - [x] A
 
@@ -1492,7 +1492,7 @@ As Steve Krug once said, happy talk must die.
 <meter>
 ```
 
-#### Q94. What is wrong with this code?
+#### Q91. What is wrong with this code?
 
 `<img src="https://source.unsplash.com/random">`
 
@@ -1501,7 +1501,7 @@ As Steve Krug once said, happy talk must die.
 - [ ] `<img>` is not a valid HTML element. Instead, use `<image src="..."/>`.
 - [ ] `<img>` should be nested within a `<figure>` tag.
 
-#### Q95. Which choice is the most semantically correct markup for specifying the first definition of a term?
+#### Q92. Which choice is the most semantically correct markup for specifying the first definition of a term?
 
 - [ ] `<p>`The `<dl>`focal length`</dl>` of a lens gives the distance from the lens to the image sensor.`</p>`
 - [x] `<p>`The `<dfn>`focal length`<dfn>` of a lens gives the distance from the lens to the image sensor.`</p>`
@@ -1512,7 +1512,7 @@ As Steve Krug once said, happy talk must die.
 
 [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)
 
-#### Q96. Which choice is the best way to code three choices within a form so that the user can select multiple items?
+#### Q93. Which choice is the best way to code three choices within a form so that the user can select multiple items?
 
 - [ ] :
 
@@ -1550,21 +1550,21 @@ As Steve Krug once said, happy talk must die.
 
 [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox)
 
-#### Q97. How would you mark up a piece of ASCII art (an emoticon) in an accessible way?
+#### Q94. How would you mark up a piece of ASCII art (an emoticon) in an accessible way?
 
 - [x] `<pre role="emoticon" aria-label="ASCII emoticon of a shrug">¯\_(ツ)_/¯</pre>`
 - [ ] `<pre role="img" aria-label="ASCII emoticon of a shrug">¯\_(ツ)_/¯</pre>`
 - [ ] `<dfn title="ASCII emoticon of a shrug">¯\_(ツ)_/¯</dfn>`
 - [ ] `<label for="art">ASCII emoticon of a shrug</label><pre role="img" id="art">¯\_(ツ)_/¯</pre>`
 
-#### Q98. Which example is a standard way in HTML5 for adding author metadata to a page?
+#### Q95. Which example is a standard way in HTML5 for adding author metadata to a page?
 
 - [ ] `<metadata name="author" content="Author Name">`
 - [ ] `<meta name="author">Author Name</meta>`
 - [ ] `<meta name="creator" content="Author Name">`
 - [x] `<meta name="author" content="Author Name">`
 
-#### Q99. Given the following requirements, select the correct `input` configuration: An `input` that allows the user to select from a range of integer values between 0 and 100 (inclusive) in increments of 5.
+#### Q96. Given the following requirements, select the correct `input` configuration: An `input` that allows the user to select from a range of integer values between 0 and 100 (inclusive) in increments of 5.
 
 - [ ] `<input type="range" min="0" max="100" by="5" />`
 - [x] `<input type="range" min="0" max="100" step="5" />`
@@ -1575,7 +1575,7 @@ As Steve Krug once said, happy talk must die.
 
 [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range)
 
-#### Q100. Which choice is valid markup for a `<head>` element?
+#### Q97. Which choice is valid markup for a `<head>` element?
 
 - [ ] `<head class="Page Section Information" id="head"><title>Page Title</title></head>`
 - [ ] `<head><title>Page Title</title> <img src="favicon.icon" alt=""></head>`
@@ -1586,7 +1586,7 @@ As Steve Krug once said, happy talk must die.
 [Source 1](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)/
 [Source 2](https://www.w3schools.com/tags/tag_data.asp)
 
-#### Q101. You need to add comments to the company blog. What is the most semantic markup for a list of comments?
+#### Q98. You need to add comments to the company blog. What is the most semantic markup for a list of comments?
 
 - [x] A
 
@@ -1631,7 +1631,7 @@ As Steve Krug once said, happy talk must die.
 `The <article> HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Example:a user-submitted comment.`
 [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
 
-#### Q102. To make something editable by the user, you need to set the **\_** attribute to **\_**.
+#### Q99. To make something editable by the user, you need to set the **\_** attribute to **\_**.
 
 - [ ] `access`; allow
 - [ ] `designMode`; true
@@ -1641,7 +1641,7 @@ As Steve Krug once said, happy talk must die.
 `The contenteditable global attribute is an enumerated attribute indicating if the element should be editable by the user. If so, the browser modifies its widget to allow editing. The attribute must take one of the following values: true or an empty string, which indicates that the element is editable; false, which indicates that the element is not editable.`
 [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)
 
-#### Q103. Which choice is the standard way to include a value in a form without making it visible to or editable by the user?
+#### Q100. Which choice is the standard way to include a value in a form without making it visible to or editable by the user?
 
 - [ ] `<input type="invisible" name="important" value="information">`
 - [ ] `<input type="text" style="display: none;" name="important" value="information">`
@@ -1650,7 +1650,7 @@ As Steve Krug once said, happy talk must die.
 
 `<input> elements of type hidden let web developers include data that cannot be seen or modified by users when a form is submitted. For example, the ID of the content that is currently being ordered or edited, or a unique security token. Hidden inputs are completely invisible in the rendered page, and there is no way to make it visible in the page's content.` [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/hidden)
 
-#### Q104. What is the semantic way to add an identifying title to a table?
+#### Q101. What is the semantic way to add an identifying title to a table?
 
 - [ ] `<table><label>Heading</label>...</table>`
 - [ ] `<table><title>Heading</title>...</table>`
@@ -1659,7 +1659,7 @@ As Steve Krug once said, happy talk must die.
 
 `The <caption> HTML element specifies the caption (or title) of a table.` [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)
 
-#### Q105. Which image file referenced in this `img` element's `srcset` attribute should a browser on a small mobile phone load?
+#### Q102. Which image file referenced in this `img` element's `srcset` attribute should a browser on a small mobile phone load?
 
 ```html
 <img
@@ -1677,7 +1677,7 @@ As Steve Krug once said, happy talk must die.
 
 `The browser will: 1. Look at its device width. 2. Work out which media condition in the sizes list is the first one to be true. 3. Look at the slot size given to that media query. 4. Load the image referenced in the srcset list that has the same size as the slot or, if there isn't one, the first image that is bigger than the chosen slot size.` [Source](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
 
-#### Q106. Which description is coded correctly?
+#### Q103. Which description is coded correctly?
 
 - [x] A
 
@@ -1726,7 +1726,7 @@ As Steve Krug once said, happy talk must die.
 [Source 1](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element)
 [Source 2](https://www.w3schools.com/tags/tag_dl.asp)
 
-#### Q107. What is wrong with this code?
+#### Q104. What is wrong with this code?
 
 ```html
 <ul>
@@ -1745,14 +1745,14 @@ As Steve Krug once said, happy talk must die.
 
 `ul content model only accepts "Zero or more li and script-supporting elements".` [Source](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element)
 
-#### Q108. A designer gave you CSS code that should run only when the device rendering the page is in dark mode. How would you embed that code?
+#### Q105. A designer gave you CSS code that should run only when the device rendering the page is in dark mode. How would you embed that code?
 
 - [ ] `<style media="light-mode: false">/* CSS code */</style>`
 - [ ] `<style media="color-mode: dark">/* CSS code */</style>`
 - [x] `<style media="prefers-color-scheme: dark">/* CSS code */</style>`
 - [ ] `<style media="color-scheme: dark">/* CSS code */</style>`
 
-#### Q109. How would you mark up a header for a table row?
+#### Q106. How would you mark up a header for a table row?
 
 - [x] A
 

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1515,21 +1515,37 @@ As Steve Krug once said, happy talk must die.
 
 #### Q96. Which choice is the best way to code three choices within a form so that the user can select multiple items?
 
-- [ ] <input type="radio" name="example"> Choice 1 <br/>
-      <input type="radio" name="example"> Choice 2 <br/>
-      <input type="radio" name="example"> Choice 3
+- [ ] :
 
-- [x] <input type="checkbox" name="example"> Choice 1 <br/>
-      <input type="checkbox" name="example"> Choice 2 <br/>
-      <input type="checkbox" name="example"> Choice 3
+```html
+<input type="radio" name="example"> Choice 1 <br/>
+<input type="radio" name="example"> Choice 2 <br/>
+<input type="radio" name="example"> Choice 3
+```
 
-- [ ] <label><input type="checkbox" name="example"> Choice 1</label><br/>
-      <label><input type="checkbox" name="example"> Choice 2</label><br/>
-      <label><input type="checkbox" name="example"> Choice 3</label>
+- [x] :
 
-- [ ] <label><input type="radio" name="example"> Choice 1</label><br/>
-      <label><input type="radio" name="example"> Choice 2</label><br/>
-      <label><input type="radio" name="example"> Choice 3</label>
+```html
+<input type="checkbox" name="example"> Choice 1 <br/>
+<input type="checkbox" name="example"> Choice 2 <br/>
+<input type="checkbox" name="example"> Choice 3
+```
+
+- [ ] :
+
+```html
+<label><input type="checkbox" name="example"> Choice 1</label><br/>
+<label><input type="checkbox" name="example"> Choice 2</label><br/>
+<label><input type="checkbox" name="example"> Choice 3</label>
+```
+
+- [ ] :
+
+```html
+<label><input type="radio" name="example"> Choice 1</label><br/>
+<label><input type="radio" name="example"> Choice 2</label><br/>
+<label><input type="radio" name="example"> Choice 3</label>
+```
 
 `<input> elements of type checkbox are rendered by default as boxes that are checked (ticked) when activated, like you might see in an official government paper form. The exact appearance depends upon the operating system configuration under which the browser is running. Generally this is a square but it may have rounded corners.`
 

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1343,13 +1343,6 @@ As Steve Krug once said, happy talk must die.
 - [ ] D
       ![D](images/Q84-4.jpg)
 
-#### Q82. In this code, what is _target_?
-
-- [x] an attribute
-- [ ] a tag
-- [ ] content
-- [ ] an element
-
 #### Q83. What is the difference between the `<svg>` and `<canvas>`?
 
 - [x] `<svg>` produces vector graphics, while `<canvas>` produces raster graphics.

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1006,7 +1006,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 [Reference (w3schools)](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_video)
 
-#### Q63. What is the correct way to describe an empty element?
+#### Q63. What is the correct way to describe an empty element / Alt.: What is the correct way to describe an empty element, such as a line break tag?
 
 - [ ] It has opening and closing tags but no child content.
 - [ ] It display nothing on a website.
@@ -1311,13 +1311,6 @@ As Steve Krug once said, happy talk must die.
 - [ ] HTML structures and provides a rudimentary look to webpages.
 - [ ] HTML is responsible for the structure, styling, and interactivity of webpages.
 - [ ] HTML is responsible for the structure and styling of webpages.
-
-#### Q79. What is the correct way to describe an empty element, such as a line break tag?
-
-- [ ] It displays nothing on a website.
-- [ ] It has opening and closing tags but no child content.
-- [ ] It has child content but no closing tag.
-- [x] It has no child content and no closing tag.
 
 #### Q80. For the HTML code below, when will "Sample Text" display to the browser?
 

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -708,6 +708,14 @@ This is a confusing question and there can be an arguments for both the second a
 - [ ] `<body>`
 - [ ] `<root>`
 
+`
+The <html> tag is the root element of an HTML document, which means that it contains all the contents and tags of the HTML document within it.
+
+The html element represents the root of a document.
+`
+[Source](https://www.interviewbit.com/html-mcq/)
+[Source](https://www.w3.org/TR/2010/WD-html-markup-20100624/html.html)
+
 #### Q44. Which code snippet creates the layout shown, starting at `<table>` and ending at `</table>`?
 
 ![Table](images/ss-1.png?raw=true 'table')
@@ -1793,18 +1801,3 @@ As Steve Krug once said, happy talk must die.
   </tr>
 </table>
 ```
-
-#### Q111. What is the root element of an HTML document.
-
-- [x] `<html>`
-- [ ] `<body>`
-- [ ] `<root>`
-- [ ] `<!DOCTYPE html>`
-
-`
-The <html> tag is the root element of an HTML document, which means that it contains all the contents and tags of the HTML document within it.
-
-The html element represents the root of a document.
-`
-[Source](https://www.interviewbit.com/html-mcq/)
-[Source](https://www.w3.org/TR/2010/WD-html-markup-20100624/html.html)

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -211,10 +211,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 ```html
 <p>
-  On <time datetime="1969-07-21">July 21, 1969</time>, Neil Armstrong said,
-  <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
-    >One small step for man, one giant leap for mankind.</q
-  >
+  On <time datetime="1969-07-21">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html">One small step for man, one giant leap for mankind.</q>
 </p>
 ```
 
@@ -222,10 +219,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 ```html
 <p>
-  On July 21, 1969, Neil Armstrong said,
-  <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
-    >One small step for man, one giant leap for mankind.</q
-  >
+  On July 21, 1969, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html">"One small step for man, one giant leap for mankind."</q>
 </p>
 ```
 
@@ -233,7 +227,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 ```html
 <p>
-  On July 21, 1969, Neil Armstrong said, <q>One small step for man, one giant leap for mankind.</q>
+  On July 21, 1969, Neil Armstrong said, <q>"One small step for man, one giant leap for mankind."</q>
 </p>
 ```
 
@@ -241,10 +235,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 ```html
 <p>
-  On <time datetime="07-21-1969">July 21, 1969</time>, Neil Armstrong said,
-  <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
-    >One small step for man, one giant leap for mankind.</q
-  >
+  On <time datetime="07-21-1969">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html">One small step for man, one giant leap for mankind.</q>
 </p>
 ```
 
@@ -1801,32 +1792,6 @@ As Steve Krug once said, happy talk must die.
     <td>18</td>
   </tr>
 </table>
-```
-
-#### Q110. What is the best semantic markup for this sentence? On July 21, 1969, Neil Armstrong said, "That's one small step for man, one giant leap for mankind.
-
-- [x] A
-
-```html
-  <p>On <time datetime="1969-07-21">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">That's one small step for man, one giant leap for mankind.</q></p>
-```
-
-- [ ] B
-
-```html
-<p>On <time datetime="07-21-1969">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">That's one small step for man, one giant leap for mankind.</q></p>
-```
-
-- [ ] C
-
-```html
-<p>On July 21, 1969, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">"That's one small step for man, one giant leap for mankind."</q></p>
-```
-
-- [ ] D
-
-```html
-<p>On July 21, 1969, Neil Armstrong said, <q>"That's one small step for man, one giant leap for mankind."</q></p>
 ```
 
 #### Q111. What is the root element of an HTML document.

--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -203,13 +203,13 @@
 
 #### Q19. What is the best semantic markup for the sentence shown?
 
-```markdown
+```
 On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap for mankind."
 ```
 
 - [x] A
 
-```markdown
+```html
 <p>
   On <time datetime="1969-07-21">July 21, 1969</time>, Neil Armstrong said,
   <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
@@ -220,7 +220,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] B
 
-```markdown
+```html
 <p>
   On July 21, 1969, Neil Armstrong said,
   <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
@@ -231,7 +231,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] C
 
-```markdown
+```html
 <p>
   On July 21, 1969, Neil Armstrong said, <q>One small step for man, one giant leap for mankind.</q>
 </p>
@@ -239,7 +239,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] D
 
-```markdown
+```html
 <p>
   On <time datetime="07-21-1969">July 21, 1969</time>, Neil Armstrong said,
   <q cite="https://www.hq.nasa.gov/alsj/a11l/a11.html"
@@ -272,7 +272,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] A
 
-```markdown
+```html
 <label for="example">Make a choice:</label>
 <datalist id="example">
 
@@ -284,7 +284,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] B
 
-```markdown
+```html
 <p>Make a choice:</p>
 <input id="choices" name="example" />
 
@@ -297,7 +297,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] C
 
-```markdown
+```html
 <label for="example">Make a choice:</label>
 <input list="example" id="choices" name="choices" />
 
@@ -310,7 +310,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [x] D
 
-```markdown
+```html
 <label for="example">Make a choice:</label>
 <input list="choices" id="example" name="example" />
 
@@ -351,7 +351,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] A
 
-```markdown
+```html
 <table>
   <scope cols="2" style="background-color: yellow">
   <tr>
@@ -369,7 +369,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [x] B
 
-```markdown
+```html
 <table>
   <colgroup span="2" style="background-color: yellow">
   <tr>
@@ -387,7 +387,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] C
 
-```markdown
+```html
 <table>
   <group cols="2" style="background-color: yellow">
   <tr scope="row">
@@ -405,7 +405,7 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 - [ ] D
 
-```markdown
+```html
 <table>
   <columns colspan="2" style="background-color: yellow">
   <tr>
@@ -434,7 +434,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 #### Q27. What should fill the two blanks in the HTML code below?
 
-```markdown
+```html
 <section itemscope itemtype="http://schema.org/Restaurant">
   <h1 itemprop="name">Nadia's Garden</h1>
   <p itemscope ______ ______>
@@ -453,7 +453,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] A
 
-```markdown
+```html
 <a id="top"></a>
 
 <!-- placed at the top of the page -->
@@ -463,7 +463,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] B
 
-```markdown
+```html
 <a name="top"></a>
 
 <!-- placed at the top of the page -->
@@ -473,13 +473,13 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] C
 
-```markdown
+```html
 <a href="#">back to top</a> <a href="#top">back to top</a>
 ```
 
 - [ ] D
 
-```markdown
+```html
 <button href="#">back to top</button> <button href="#top">back to top</button>
 ```
 
@@ -551,7 +551,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] A
 
-```markdown
+```html
 <ul>
   <li>
     office
@@ -571,7 +571,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] B
 
-```markdown
+```html
 <ul>
   <li>Office Supplies
     <ul>
@@ -589,7 +589,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] C
 
-```markdown
+```html
 <ul>
   <li>office</li>
   <li>staple</li>
@@ -616,7 +616,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] A
 
-```markdown
+```html
 <p>
   "Making money is what you have to do to sustain a business—being driven to make something of value
   and purpose is much more powerful."
@@ -626,7 +626,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] B
 
-```markdown
+```html
 <blockquote>
   <q
     >"Making money is what you have to do to sustain a business—being driven to make something of
@@ -638,7 +638,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] C
 
-```markdown
+```html
 <blockquote>
   <p>
     "Making money is what you have to do to sustain a business—being driven to make something of
@@ -650,7 +650,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] D
 
-```markdown
+```html
 <section>
   <q
     >"Making money is what you have to do to sustain a business—being driven to make something of
@@ -683,7 +683,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 #### Q40. What does this code do?
 
-```markdown
+```html
 <audio controls>
   <source src="sound.mp3" type="audio/mpeg" />
   <source src="sound.ogg" type="audio/ogg" />
@@ -723,7 +723,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] A
 
-```markdown
+```html
 <tr>
   <td>Table cell 1</td>
   <td>Table cell 2</td>
@@ -735,7 +735,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] B
 
-```markdown
+```html
 <tr>
   <td>Table cell 1</td>
   <td>Table cell 2</td>
@@ -745,7 +745,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] C
 
-```markdown
+```html
 <tr>
   <td>Table cell 1</td>
   <td>Table cell 2</td>
@@ -757,7 +757,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] D
 
-```markdown
+```html
 <tr>
   <td>Table cell 1</td>
   <td>Table cell 2</td>
@@ -778,7 +778,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] A
 
-```markdown
+```html
 <form>
   <legend>Title</legend>
   <fieldset>
@@ -791,7 +791,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] B
 
-```markdown
+```html
 <form>
   <fieldset>
     <legend>Title</legend>
@@ -804,7 +804,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] C
 
-```markdown
+```html
 <form>
   <fieldset>
     <legend>Title</legend>
@@ -817,7 +817,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] D
 
-```markdown
+```html
 <form>
   <legend>Title</legend>
   <label for="name">Your name:</label>
@@ -910,7 +910,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 #### Q57. Review the code below. How do you include subnavigation for Link 2 that includes a link?
 
-```markdown
+```html
 <nav><ul>
   <li><a href="#">Link 1</a></li>
   <li><a href="#">Link 2</a></li>
@@ -920,7 +920,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] A
 
-```markdown
+```html
 <nav><ul>
   <li><a href="#">Link 1</a></li>
   <li><a href="#">Link 2</a></li>
@@ -933,7 +933,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [x] B
 
-```markdown
+```html
 <nav><ul>
   <li><a href="#">Link 1</a></li>
   <li><a href="#">Link 2</a>
@@ -947,7 +947,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] C
 
-```markdown
+```html
 <ul><nav>
   <li><a href="#">Link 1</a></li>
   <li><a href="#">Link 2</a>
@@ -961,7 +961,7 @@ This is a confusing question and there can be an arguments for both the second a
 
 - [ ] D
 
-```markdown
+```html
 <nav><ul>
   <li><a href="#">Link 1</a></li>
   <li><a href="#">Link 2</a></li>
@@ -1075,7 +1075,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] A
 
-```HTML
+```html
 <caption>A table</caption>
   <table>
     <td>
@@ -1087,7 +1087,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] B
 
-```HTML
+```html
 <caption>A table</caption>
 <table>
   <tr>
@@ -1099,7 +1099,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [x] C
 
-```HTML
+```html
 <table>
   <caption>A table</caption>
   <tr>
@@ -1111,7 +1111,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] D
 
-```HTML
+```html
 <table>
   <tr>
     <td>Cell 1</td>
@@ -1143,7 +1143,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] A
 
-```HTML
+```html
 <area>
 <embed>
 <strong>
@@ -1151,7 +1151,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] B
 
-```HTML
+```html
 <input>
 <br>
 <p>
@@ -1159,7 +1159,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [ ] C
 
-```HTML
+```html
 <link>
 <meta>
 <title>
@@ -1167,7 +1167,7 @@ References [(MDN) audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Eleme
 
 - [x] D
 
-```HTML
+```html
 <wbr>
 <base>
 <source>
@@ -1218,7 +1218,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] A
 
-```markdown
+```html
 <p>
   <a href="index.html">Home</a>
   <a href="about.html">About</a>
@@ -1228,7 +1228,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```markdown
+```html
 <nav>
   <a href="index.html">Home</a>
   <a href="about.html">About</a>
@@ -1238,7 +1238,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```markdown
+```html
  <nav>
     <ol>
       <li><a href="index.html">Home</a></li>
@@ -1250,7 +1250,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] D
 
-```markdown
+```html
  <nav>
    <ul>
      <li><a href="index.html">Home</a></li>
@@ -1266,7 +1266,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```markdown
+```html
 <h4>Mailing Address</h4>
 <address>
   6410 Via Real <br>
@@ -1277,7 +1277,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```markdown
+```html
 <h4><strong>Mailing Address</h4>
 <address><em>
   6410 Via Real <br>
@@ -1288,7 +1288,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```markdown
+```html
 <h4>Mailing Address</h4>
 <p><em>
   6410 Via Real <br>
@@ -1299,7 +1299,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```markdown
+```html
 <p><strong>Mailing Address</strong></p>
 <p><em>
   6410 Via Real <br>
@@ -1328,7 +1328,7 @@ As Steve Krug once said, happy talk must die.
 
 #### Q80. For the HTML code below, when will "Sample Text" display to the browser?
 
-```markdown
+```html
 <noscript>Sample Text</noscript>
 ```
 
@@ -1341,7 +1341,7 @@ As Steve Krug once said, happy talk must die.
 
 #### Q81. How will this code render by default in most web browsers?
 
-```markdown
+```html
 <details>
   <h4>Mixed Berry Tart.</h4>
   <p>Raspberries, blueberries, and strawberries on top of a creamy filling served in a crispy tart.</p>
@@ -1395,7 +1395,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] A
 
-```HTML
+```html
 <button submit="http://example.com/process">
   Process data
 </button>
@@ -1403,7 +1403,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```HTML
+```html
 <button action="http://example.com/process">
   Process data
 </button>
@@ -1411,7 +1411,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] C
 
-```HTML
+```html
 <button formaction="http://example.com/process">
   Process data
 </button>
@@ -1419,7 +1419,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```HTML
+```html
 <button method="http://example.com/process">
   Process data
 </button>
@@ -1442,7 +1442,7 @@ As Steve Krug once said, happy talk must die.
 
 #### Q88. What is wrong with this code snippet?
 
-```HTML
+```html
 <label>Address:</label>
 <input type="text" name="address" id="address-input" />
 ```
@@ -1484,7 +1484,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```HTML
+```html
 <li>
 <input>
 <option>
@@ -1492,7 +1492,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```HTML
+```html
 <input>
 <option>
 <textarea>
@@ -1500,7 +1500,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```HTML
+```html
 <button>
 <input>
 <form>
@@ -1508,7 +1508,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```HTML
+```html
 <input>
 <label>
 <meter>
@@ -1596,7 +1596,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```HTML
+```html
 <aside>
   <h3>Comments</h3>
   <article> First comment.</article>
@@ -1606,7 +1606,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```HTML
+```html
 <div aria="dpub-comments">
   <h3>Comments</h3>
   <div aria="dpub-comment"> First comment.</div>
@@ -1616,7 +1616,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```HTML
+```html
 <aside>
   <h3>Comments</h3>
   <aside> First comment.</aside>
@@ -1626,7 +1626,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```HTML
+```html
 <div typeof="comments">
   <h3>Comments</h3>
   <div typeof="comment"> First comment.</div>
@@ -1687,7 +1687,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```HTML
+```html
 <dl>
   <dt>Server</dt>
   <dd>Software used to serve webpages, like Apache.</dd>
@@ -1698,7 +1698,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```HTML
+```html
 <dt>
   <dl>Server</dl>
   <dd>Software used to serve webpages, like Apache.</dd>
@@ -1709,7 +1709,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```HTML
+```html
 <dl>
   <dt>Server</dt>
   <dd>Software used to serve webpages, like Apache.</dd>
@@ -1720,7 +1720,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```HTML
+```html
 <dl>
   <dd>Server</dd>
   <dt>Software used to serve webpages, like Apache.</dt>
@@ -1734,7 +1734,7 @@ As Steve Krug once said, happy talk must die.
 
 #### Q107. What is wrong with this code?
 
-```HTML
+```html
 <ul>
   <h2>Espresso Drinks</h2>
   <li>Espresso</li>
@@ -1762,7 +1762,7 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```HTML
+```html
 <table>
   <thead scope="row"><th row="1">Header</th></thead>
   <tr>
@@ -1774,7 +1774,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] B
 
-```HTML
+```html
 <table>
   <tr>
   <th scope="row">Header</th>
@@ -1786,7 +1786,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] C
 
-```HTML
+```html
 <table>
   <tr>
     <thead scope="row">Header</thead>
@@ -1798,7 +1798,7 @@ As Steve Krug once said, happy talk must die.
 
 - [ ] D
 
-```HTML
+```html
 <table>
   <tr>
     <th>Header</th>
@@ -1812,25 +1812,25 @@ As Steve Krug once said, happy talk must die.
 
 - [x] A
 
-```HTML
+```html
   <p>On <time datetime="1969-07-21">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">That's one small step for man, one giant leap for mankind.</q></p>
 ```
 
 - [ ] B
 
-```HTML
+```html
 <p>On <time datetime="07-21-1969">July 21, 1969</time>, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">That's one small step for man, one giant leap for mankind.</q></p>
 ```
 
 - [ ] C
 
-```HTML
+```html
 <p>On July 21, 1969, Neil Armstrong said, <q cite="https://www.hq.nasa.gov/alsj/a11/a11.step.html">"That's one small step for man, one giant leap for mankind."</q></p>
 ```
 
 - [ ] D
 
-```HTML
+```html
 <p>On July 21, 1969, Neil Armstrong said, <q>"That's one small step for man, one giant leap for mankind."</q></p>
 ```
 


### PR DESCRIPTION
Hello,

here are some fixes for problems I encountered when training with the HTML quiz:

In brief:

+ standardize/fix HTML fenced code blocks, because there were a lot of rendering issues (`HTML` to `html` for Q68, Q71, Q86, Q88, Q93, Q101, Q106, Q107, Q109, Q110;  `markdown` to `html` for Q19, Q22, Q25, Q27, Q28, Q34, Q36, Q40, Q44, Q46, Q57,
 Q76, Q77, Q80, Q81);
+ remove Q61, duplicate of Q26, taking in account alternative formulations;
+ remove Q79, duplicate of Q63, taking in account alternative formulations;
+ remove Q82 (incomplete), duplicate of Q85 (complete);
+ add the missing HTML fenced code blocks in Q96;
+ remove Q110, duplicate of Q19, and fix the HTML formatting in Q19, which was causing rendering issues;
+ remove Q111, duplicate of Q43, moving the explanation with references from Q111 to Q43;
+ and finally, automatically renumber questions after last removals.

I encountered quiz rendering issues for Q28, Q77, Q81, Q93, Q101, Q106, Q109 (among other questions) - we will see if all the changes above fix these issues.

Pings: nobody.

Hope it helps,
and thanks again for this project!
