### PR TITLE
Fixes #3950 php Q43 wrong answer

### DIFF
--- a/php/php-quiz.md
+++ b/php/php-quiz.md
@@ -437,8 +437,8 @@ echo "No, mail is not set";
 
 #### Q43. Assuming that `$first_name` and `$family_name` are valid strings, which statement is invalid?
 
-- [x] `echo $first_name. ' '. $family_name;`
-- [ ] `print $first_name, ' ', $family_name;`
+- [ ] `echo $first_name. ' '. $family_name;`
+- [x] `print $first_name, ' ', $family_name;`
 - [ ] `print $first_name. ' '. $family_name;`
 - [ ] `echo $first_name, ' ', $family_name;`
 


### PR DESCRIPTION
actually print() cannot take comma separated variables without paranthesis

see example
```
$ php -a
Interactive mode enabled

php > $foo = 'Jan'; $bar = 'Silva';
php > print $foo, ' ', $bar;
PHP Parse error:  syntax error, unexpected ',' in php shell code on line 1
php > 

```