### PR TITLE
Answer for Q76.

### DIFF
--- a/spring-framework/spring-framework-quiz.md
+++ b/spring-framework/spring-framework-quiz.md
@@ -797,7 +797,7 @@ class TestConfig {
 }
 ```
 
-- [ ] formatter.getClass()
+- [x] formatter.getClass()
 - [ ] context.containsBean("formatter")
 - [ ] context.getBean("formatter").getClass()
 - [ ] context.getClass()


### PR DESCRIPTION
It was tested and the compiler pointed the java.lang.NullPointerException to System.out.println(formatter.getClass()). So you need to remove this println to stop this code form throwing the exception.