### PR TITLE
HTMLController don't even exist

### DIFF
--- a/spring-framework/spring-framework-quiz.md
+++ b/spring-framework/spring-framework-quiz.md
@@ -827,7 +827,7 @@ class TestConfig {
 
 - [ ] @Component
 - [ ] @Service
-- [ ] @HtmlController
+- [x] @HtmlController
 - [ ] @Controller
 
 #### Q81. Which statement is true regarding loading and instantiation of Spring factories?


### PR DESCRIPTION
Check this out 
https://www.geeksforgeeks.org/spring-stereotype-annotations/

"So the stereotype annotations in spring are @Component, @Service, @Repository, and @Controller."