### PR TITLE
Fixed typo in agile-methodologies/Q83 + numeration fix

### DIFF
--- a/agile-methodologies/agile-methodologies-quiz.md
+++ b/agile-methodologies/agile-methodologies-quiz.md
@@ -595,7 +595,7 @@
 - [ ] It was written in 2001 and is obsolete.
 - [ ] It was first published as part of Jim Highsmith's doctoral thesis.
 
-#### Q83. The team is not going to complete its Spring Commitment. As the Team Facilitator, what should you do?
+#### Q83. The team is not going to complete its Sprint Commitment. As the Team Facilitator, what should you do?
 
 - [ ] Ask the PO to extend the sprint.
 - [ ] Advise the PO as soon as possible.
@@ -775,7 +775,7 @@ ITIOO isn't a thing, thin verticle slicing is refering to what work you prioriti
 - [ ] Product Increment
 - [ ] Program Increment
 
-#### Q108. How an you improve interaction between team members?
+#### Q107. How an you improve interaction between team members?
 
 - [ ] Move people's workstation around in the team room to create new social possibilites
 - [ ] Since no one has come to you with a compliant, assume that the limited interaction works for everyone


### PR DESCRIPTION
Replaced the word "Spring" by "Sprint" in Q83.
Moved Q108 on one position down in numeration.

<details>
  <summary>Screenshot</summary>

![Screenshot_5](https://user-images.githubusercontent.com/48429967/183050066-7c654956-2f80-4528-9e65-77eea47c5282.png)

</details>