### PR TITLE
Update django-quiz.md

### DIFF
--- a/django/django-quiz.md
+++ b/django/django-quiz.md
@@ -481,9 +481,7 @@ model=Planet
 
 #### Q49. What is the result of this template code?
 
-```
 {{"live long and prosper"|truncate:3}}
-```
 
 - [x] live long and ...
 - [ ] live long and


### PR DESCRIPTION
The text in triple backticks is not rendered and hence is not visible/searchable on https://ebazhanov.github.io/linkedin-skill-assessments-quizzes/django/django-quiz.htm
![Screenshot 2022-08-13 at 22-16-53 Django](https://user-images.githubusercontent.com/6527493/184503321-bf87c759-4f7a-4b69-a729-6b1f6ccfd9d4.png)
l