### PR TITLE
difference between constructor, setter injection

### DIFF
--- a/spring-framework/spring-framework-quiz.md
+++ b/spring-framework/spring-framework-quiz.md
@@ -767,7 +767,7 @@ public Pojo getPojo(@PathVariable("id") String id) {
 
 - [ ] Constructor injection overrides setter injection.
 - [ ] Setter injection creates a new instance if any modification occurs.
-- [ ] You can't use constructor injection for partial injection.
+- [x] You can't use constructor injection for partial injection.
 - [ ] Constructor injection is more flexible than setter injection.
 
 #### Q76. Which println would you remove to stop this code from throwing a null pointer exception?


### PR DESCRIPTION
There are many key differences between constructor injection and setter injection.

1) **Partial dependency**: can be injected using setter injection but it is not possible by constructor. Suppose there are 3 properties in a class, having 3 arg constructor and setters methods. In such case, if you want to pass information for only one property, it is possible by setter method only.
2) **Overriding**: Setter injection overrides the constructor injection. If we use both constructor and setter injection, IOC container will use the setter injection.
3) **Changes**: We can easily change the value by setter injection. It doesn't create a new bean instance always like constructor. So setter injection is flexible than constructor injection.