### PR TITLE
update typo c-sharp-quiz.md

### DIFF
--- a/c-sharp/c-sharp-quiz.md
+++ b/c-sharp/c-sharp-quiz.md
@@ -720,7 +720,7 @@ public int Password
 
 #### Q66. Do you need to declare an out variable before you use it?
 
-- [x] `No, you can declare it in the parameter list.`
+- [x] `No, you can declare an out in the parameter list.`
 - [ ] `Out variables are no longer part of C#.`
 - [ ] `You must declare it if it is a primitive type.`
 - [ ] `Yes.`


### PR DESCRIPTION
There was a typo in question 66. Instead of "it" the answer has "an out". The answer here was:
"No, you can declare "it" in the parameter list."  but in LinkedIn it is: 
"No, you can declare "an out" in the parameter list."