### PR TITLE
Added answer and reference to Angular Q55

### DIFF
--- a/angular/angular-quiz.md
+++ b/angular/angular-quiz.md
@@ -1074,7 +1074,9 @@ RouterModule.forRoot (
 - [ ] It enables the option to flag individual routes for preloading.
 - [ ] It preloads all dependencies for routes, creating instances of services when the app first starts up
 - [ ] It ensures all modules get built into a single app module bundle file.
-- [ ] It configures the router to immediately load all routes that have a loadChildren property(routes that are typically loaded when requested)
+- [x] It configures the router to immediately load all routes that have a loadChildren property(routes that are typically loaded when requested)
+
+[Reference](https://medium.com/geekculture/preloading-strategy-in-angularsave-loading-time-ca791074fe28)
 
 #### Q56. What is an alternative way to write this markup to bind the value of the class field `userName` to the `h1` element title property?
 


### PR DESCRIPTION
I've look over several articles (see my comment in discussion). I believe the answer is D "It configures the router to immediately load all routes that have a loadChildren property (routes that are typically loaded when requested)"

Because,
The default behavior is Load on Demand (as stated in the parenthetical on the response);
It does, in fact, load all the routes that have configured with the loadChildren statement;
It do not find anything indicating that instances of services are automatically created.