### PR TITLE
XML: Added a new question, Bugfix: Q41 wasn't correctly displayed in …

### DIFF
--- a/xml/xml-quiz.md
+++ b/xml/xml-quiz.md
@@ -546,12 +546,12 @@ car#year {
 }
 ```
 
-#### Q41. An XML document contains this code as part of the DTD: <!ELEMENT car (make, model?, year+, price*)>. What are the rules that need to be followed for each of the elements?
+#### Q41. An XML document contains this code as part of the DTD: `<!ELEMENT car (make, model?, year+, price*)>`. What are the rules that need to be followed for each of the elements?
 
-- [ ] <make> is required, <model> is optional, <year> is optional, and <price> is optional.
-- [ ] <make> is required, <model> is required, <year> is optional, and <price> is optional.
-- [ ] <make> is required, <model> is required, <year> is required, and <price> is optional.
-- [x] <make> is required, <model> is optional, <year> is required, and <price> is optional.
+- [ ] `<make>` is required, `<model>` is optional, `<year>` is optional, and `<price>` is optional.
+- [ ] `<make>` is required, `<model>` is required, `<year>` is optional, and `<price>` is optional.
+- [ ] `<make>` is required, `<model>` is required, `<year>` is required, and `<price>` is optional.
+- [x] `<make>` is required, `<model>` is optional, `<year>` is required, and `<price>` is optional.
 
 #### Q42. Which element in this XML code is not a good candidate for conversion into an attribute?
 
@@ -608,3 +608,16 @@ car#year {
 - [ ] `nextSibling`
 - [x] `nodeValue`
 - [ ] `nodename`
+
+#### Q47. If you open up the document below in a web browser, what result do you expect?
+
+```xml
+<document >
+    ´<.msg-1>Hello World!</.msg-1>
+</document>
+```
+
+- [ ] The browser will display the entire XML document.
+- [ ] The browser will display just the string Hello World!
+- [ ] The browser will report a syntax error because it includes an element that has a hyphen character.
+- [x] The browser will report a syntax error because it includes an element that starts with a period.


### PR DESCRIPTION
![Unbenannt](https://user-images.githubusercontent.com/8059717/195342356-2ff1c03b-d2e0-4d4c-ac7d-e28e11e934be.png)

I just got this new question. Also while testiing Q41 had no `-Tags before the inline xml, so the code wasn't displayed correctly.