### PR TITLE
Add alternative version of invalid json question

### DIFF
--- a/json/json-quiz.md
+++ b/json/json-quiz.md
@@ -951,3 +951,10 @@ myVehicleContents.van.inside['inside'] = gloveBoxContents;
 - [ ] nested
 
 `YAML supports # comments but not JSON`
+
+#### Q87. Which is an invalid JSON value? (same as previous question, but different possible answers)
+
+- [ ] `"'|=(_)(X 72(_)|\/||*'"`
+- [x] `"\s(_)(X 72(_)|\/||*"`
+- [ ] `"|=(_)(X\" \"72(_)|\/||*"`
+- [ ] `"|=(_)(X 72(_)|\/||*"`


### PR DESCRIPTION
Add alternative version of the invalid JSON value question. This question is the same as question 22, HOWEVER, the answer options I was provided with were different. Maybe they have an alternative version of this question, or maybe they have updated the answer options.

In any case, I thought it would be good to add this version as well to help out others.

This is for Hacktoberfest.