### PR TITLE
HACKTOBERFEST Fix javascript-quiz Q26

### DIFF
--- a/javascript/javascript-quiz.md
+++ b/javascript/javascript-quiz.md
@@ -383,10 +383,10 @@ dessert.type = 'pudding';
 
 #### Q26. Which of the following operators can be used to do a short-circuit evaluation?
 
-- [ ] `\++`
-- [ ] `\--`
-- [ ] `\==`
-- [x] `\|\|`
+- [ ] `++`
+- [ ] `--`
+- [ ] `==`
+- [x] `||`
 
 [Reference short circuit javascript](https://codeburst.io/javascript-what-is-short-circuit-evaluation-ff22b2f5608c)
 


### PR DESCRIPTION
The markdown displays the escape character \ as well: "\|\|" instead of "||". In this PR the "\" is removed.