### PR TITLE
HACKTOBERFEST: Fix javascript-quiz Q38

### DIFF
--- a/javascript/javascript-quiz.md
+++ b/javascript/javascript-quiz.md
@@ -517,10 +517,10 @@ let diff = function (x, y) {
 [] == [];
 ```
 
-- [ ] True
+- [ ] true
 - [ ] undefined
 - [ ] []
-- [x] False
+- [x] false
 
 [Reference arrays in js are objects](https://stackoverflow.com/questions/30820611/why-doesnt-equality-check-work-with-arrays)
 


### PR DESCRIPTION
Since it is javascript a boolean will evaluate to "true" or "false" instead of "True" or "False"