### PR TITLE
HACKTOBERFEST: Fix small typo in javascript-quiz

### DIFF
--- a/javascript/javascript-quiz.md
+++ b/javascript/javascript-quiz.md
@@ -822,7 +822,7 @@ printA();
 
 [Reference break vs continue](https://www.w3schools.com/js/js_break.asp)
 
-#### Q64. Which choice is valid example for an arrow function?
+#### Q64. Which choice is a valid example for an arrow function?
 
 - [x] `(a,b) => c`
 - [ ] `a, b => {return c;}`


### PR DESCRIPTION
In Q64 an "a" was missing