### PR TITLE
Add new question + answer (#82) to jQuery assessment

### DIFF
--- a/jquery/jquery-quiz.md
+++ b/jquery/jquery-quiz.md
@@ -1575,3 +1575,14 @@ $('.items').find('li:first-child').fadeOut().next('.active').fadeTo('fast', 0.5)
 - [ ] :nth-of-type, which can select elements that are the nth element of their type within their parent
 
 [Source: Selectors Level 4](https://drafts.csswg.org/selectors/)
+
+#### Q82. jQuery is quite large, and developers often do not use all of its functionality on a project. Beyond using the slim build of jQuery 3, how can you use some of jQuery, but not all?
+
+- [ ] None of these--the only viable options are the full build or slim build of jQuery.
+- [ ] Download the minified build from the JQuery CDN and strip out functions manually.
+- [x] Download the source code from GitHub and build a custom version that excludes the unnecessary modules.
+- [ ] Download the developer build from code.jquery.com and gzip it.
+
+[Source: jQuery GitHub repo](https://github.com/jquery/jquery#modules)
+
+**Explanation**: Special builds can be created that exclude subsets of jQuery functionality. This allows for smaller custom builds when the builder is certain that those parts of jQuery are not being used.


### PR DESCRIPTION
## Description 
I took the jQuery test on `Nov 11th, 2022`, and noticed that this question was not part of this repo. Even though the question is tricky, there is a very solid answer provided by jQuery's repo itself. Added the question, the options, the correct answer, a source, and a short explanation.

## Screenshot of question

![new](https://user-images.githubusercontent.com/19642693/201491647-e4dc05b6-e237-4a51-9bbd-ab6515541146.png)
