### PR TITLE
Changed answer #12 to correct

### DIFF
--- a/c-(programming-language)/c-(programming-language)-quiz.md
+++ b/c-(programming-language)/c-(programming-language)-quiz.md
@@ -235,8 +235,8 @@ main(){
 #### Q12. Which is the smallest program to compile and run without errors?
 
 - [ ] main()
-- [ ] int main() {return 0;}
-- [x] main() { }
+- [x] int main() {return 0;}
+- [ ] main() { }
 - [ ] main() { ; }
 
 [Reference](https://www.beningo.com/150-the-wolrds-shortest-c-program/)


### PR DESCRIPTION
In the C standards (C90 and C99) allow for two different definitions of main as int main(void) {/* … */}
or
int main(int argc, char *argv[]) { /* … */ }
But variant void main(void){} also can to ran, but with warning 
See [Reference](https://www.beningo.com/150-the-wolrds-shortest-c-program/)

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [ ] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
