### PR TITLE
:pencil: fix: 'tables' instead of 'variables'

### DIFF
--- a/mysql/mysql-quiz.md
+++ b/mysql/mysql-quiz.md
@@ -731,7 +731,7 @@ WHERE MATCH(address) AGAINST ('street, drive');
 
 - [ ] Stored procedures are not secure, because they can be executed from the command line as the root user
 - [ ] Stored procedures are secure, because the owner of the stored procedure can decide to whom access is granted
-- [x] Stored procedures are secure, because applications can be given access to stored procedures and not any underlying variables
+- [x] Stored procedures are secure, because applications can be given access to stored procedures and not any underlying tables
 - [ ] Stored procedures are not secure, because they can execute statements to drop tables or bulk delete data
 
 #### Q78. How would you retrieve data on all the customers where no phone number is stored?


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

Q77 was saying "underlying variables". In LinkedIN the option is "underlying tables".

![Screenshot from 2022-11-17 14-14-21](https://user-images.githubusercontent.com/60260322/202515841-70f17348-50d6-407e-a48d-b9977cc9beea.png)
