### PR TITLE
44th answer updated

### DIFF
--- a/c++/c++-quiz.md
+++ b/c++/c++-quiz.md
@@ -811,18 +811,18 @@ complexNumber(float real, float im) {
 
 ```cpp
 bool x=true, y=false;
-if(~x || y){
+
+if (~x || y) {
     /*part A*/
-}
-else{
+} else {
     /*part B*/
 }
 ```
 
-- [ ] Part A executes because the expression `(~x || y)` always results in true if `y==false`.
+- [x] Part A executes because the expression `(~x || y)` always results in true if `y==false`.
 - [ ] Part B executes because the statement `(~x || y)` is invalid, thus false.
 - [ ] Part A executes because `~x` is not zero, meaning true.
-- [x] Part B executes because `~x` is false and `y` is false, thus the `OR` operation evaluates as false.
+- [ ] Part B executes because `~x` is false and `y` is false, thus the `OR` operation evaluates as false.
 
 #### Q45. What would be the output of this code?
 


### PR DESCRIPTION
`~x` is doing a Unary complement (bit inversion).
Bitwise operators modify variables considering the bit patterns representing the values. So, If I simplify this as (-2 || false) then it obviously executes `Part A`.

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small corrections/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
