### PR TITLE
Fix wrong C++ answer(?s)

### DIFF
--- a/c++/c++-quiz.md
+++ b/c++/c++-quiz.md
@@ -554,7 +554,8 @@ int main(){
 - [ ] c = -1, which is greater than 10
 - [ ] c = 255, which is less than 10
 
-Technically, a `char` could be either `signed` or `unsigned`; in the latter case, the second answer would be correct.
+Technically, whether a `char` is `signed` or `unsigned` is implementation-defined;
+in the latter case, the second answer would be correct.
 [Reference](https://en.cppreference.com/w/cpp/language/types)
 
 #### Q35. How can C++ code call a C function?

--- a/c++/c++-quiz.md
+++ b/c++/c++-quiz.md
@@ -417,8 +417,8 @@ x=+a;
 ```
 
 - [ ] 3
-- [x] 7
-- [ ] -3
+- [ ] 7
+- [x] -3
 - [ ] 13
 
 #### Q29. Which statement is true?
@@ -553,6 +553,9 @@ int main(){
 - [ ] c = 255, which is greater than 10
 - [ ] c = -1, which is greater than 10
 - [ ] c = 255, which is less than 10
+
+Technically, a `char` could be either `signed` or `unsigned`; in the latter case, the second answer would be correct.
+[Reference](https://en.cppreference.com/w/cpp/language/types)
 
 #### Q35. How can C++ code call a C function?
 
@@ -819,9 +822,9 @@ if (~x || y) {
 }
 ```
 
-- [x] Part A executes because the expression `(~x || y)` always results in true if `y==false`.
+- [ ] Part A executes because the expression `(~x || y)` always results in true if `y==false`.
 - [ ] Part B executes because the statement `(~x || y)` is invalid, thus false.
-- [ ] Part A executes because `~x` is not zero, meaning true.
+- [x] Part A executes because `~x` is not zero, meaning true.
 - [ ] Part B executes because `~x` is false and `y` is false, thus the `OR` operation evaluates as false.
 
 #### Q45. What would be the output of this code?


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

## DOD

- [ ] I have added new quiz{'s}
- [x] I have added new reference link{'s}
- [x] I have made small correction/improvements

## Changes / Instructions

### Question 28: What is the value of `x` after running this code?
It seems to me that either the question or the answer is wrong.
Compiling and running this snippet with both `clang` and `gcc` prints `-3`:
```cpp
#include <iostream>
int main()
{
    int x = 10, a = -3;
    x = +a;
    std::cout << x << '\n';
    return 0;
}
```

The original answer, `-7`, would have been correct given this snippet instead:
```cpp
int x = 10, a = -3;
x += a;
```

@unikdahal I've seen your [recent PR here](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/pull/5256), what do you think? Which compiler did you use?

### Question 44: What is the result from executing this code snippet?
```cpp
bool x=true, y=false;

if (~x || y) {
    /*part A*/
} else {
    /*part B*/
}
```

Original answer: Part A executes because the expression (~x || y) always results in true if y==false.

Well, it's correct that part A executes, but in my opinion the correct answer is: Part A executes because `~x` is not zero, meaning true.

Assuming the boolean value is represented using one byte, `true` becomes `00000001`, and flipping its bits you get `11111110`, which is a non-zero value.
Therefore the if-condition will always evaluate to true, no matter the value of `y`.
To confirm this theory, if you compile using the `-Wbool-operation` flag, with `clang` you get a warning stating: "bitwise negation of a boolean expression always evaluates to 'true'".

@golamrabbiazad you recently [updated this answer](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/pull/5219), what do you think?

### Question 34: What is the output of this code?
```cpp
#include <cstdio>
using namespace std;

int main(){
    char c = 255;
    if(c>10)
        printf("c = %i, which is greater than 10", c);
    else
        printf("c = %i, which is less than 10", c);
    return 0;
}
```

Possible answers:
- [x] c = -1, which is less than 10
- [ ] c = 255, which is greater than 10
- [ ] c = -1, which is greater than 10
- [ ] c = 255, which is less than 10

The result is correct on my machine too, but, according to the standard, `char` could be either `signed` or `unsigned`; in the latter case, the answer would have been: "c = -1, which is greater than 10".
From the [reference](https://en.cppreference.com/w/cpp/language/types):
> The signedness of char depends on the compiler and the target platform: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.

So, either I checked something wrong, or LinkedIn should update its question.
Perhaps some veteran C++ developer can provide feedback?
