### PR TITLE
Fix syntax on question 25 in Swift

### DIFF
--- a/swift/swift-quiz.md
+++ b/swift/swift-quiz.md
@@ -282,6 +282,8 @@ if let s = String.init("some string") {
 - [ ] typealias CustomClosure -> () -> ()
 - [ ] typealias CustomClosure -> () {}
 
+[_The Swift Programming Language: Declarations: Type Alias Declaration_](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_typealias-declaration)
+
 #### Q26. How do you reference class members from within a class?
 
 - [x] self

--- a/swift/swift-quiz.md
+++ b/swift/swift-quiz.md
@@ -277,7 +277,7 @@ if let s = String.init("some string") {
 
 #### Q25. Which code snippet correctly creates a typealias closure?
 
-- [x] typealias CustomClosure: () -> ()
+- [x] typealias CustomClosure = () -> ()
 - [ ] typealias CustomClosure { () -> () }
 - [ ] typealias CustomClosure -> () -> ()
 - [ ] typealias CustomClosure -> () {}


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

As written, the answer on question 25 would not compile. It could be that the person who put it in was trying to remember the syntax from memory, as this is not the proper syntax. To verify, I went back and looked at `typealias` declarations in codebases from 2018 and tried to compile this declaration against older versions of Swift — this did not compile in Swift 4.2, Swift 5 and Swift 5.7.2 (the latest version as of 2023-01-15).

To test:

1. Install Swift on your system (if you are running macOS and have Xcode installed, you already have it)
2. Open your terminal and check your Swift version with `swift --version`. Ideally, you're on v5 or greater
3. Open the Swift REPL with `swift repl`
4. Type what was there before: `typealias CustomClosure: () -> ()`, which will cause an error
5. Type the proper syntax (added on the PR): `typealias CustomClosure = () -> ()`, which should run fine

Reference: [_The Swift Programming Language: Declarations: Type Alias Declaration_](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_typealias-declaration)
