### PR TITLE
Fix typo in Google Analytics

### DIFF
--- a/google-analytics/google-analytics-quiz.md
+++ b/google-analytics/google-analytics-quiz.md
@@ -597,9 +597,9 @@
 - [ ] on metrics only
 - [x] temporary
 
-#### Q84. What is a risk of using the Copare to Previous Period option?
+#### Q84. What is a risk of using the Compare to Previous Period option?
 
-- [ ] it is not possible to cmpare previous periods with sampled data pulled ad hoc
+- [ ] it is not possible to compare previous periods with sampled data pulled ad hoc
 - [ ] The same amount of days selected for the Date Range will be used for the coparison
 - [x] If the review period is Wednesday to Thursday, the previous period may include weekends, which may skew the comparison
 - [ ] Both sets of data may appear on the same graph, which will skew your ability to analyze impact


### PR DESCRIPTION
- [X] I have made small correction/improvements

### Changes / Instructions

Fix a typo:
- `Copare` => `Compare`
- `cmpare` => `compare`
