### PR TITLE
Q32 & Q40 On The Objective-C Assessment Have No Answers Ticked. [Missing Answer Request] #5730

### DIFF
--- a/objective-c/objective-c-quiz.md
+++ b/objective-c/objective-c-quiz.md
@@ -9,6 +9,7 @@ NSMutableString *s = [NSMutableString stringWithString: @"123"];
 
 - [x] 123456
 - [ ] 123
+- [ ] 123
 - [ ] 456
 - [ ] This code contains an error.
 
@@ -318,7 +319,7 @@ id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllo
 
 - [ ] NSString
 - [ ] NSArray
-- [ ] id
+- [x] id
 - [ ] NSDictionary
 
 #### Q33. What is significant about this function declaration?
@@ -416,7 +417,7 @@ NSlog(@"d1: %@", d1);
 - [ ] 8
 - [ ] nil
 - [ ] -1
-- [ ] undefined
+- [x] undefined
 
 #### Q41. Which thread should UI updates be processed on to avoid crashes and application lag?
 


### PR DESCRIPTION
# What does this PR do ?
Fixes: #5730 
# Type of change
### Added Missing Answer Q32 
![Screenshot from 2023-05-14 08-13-28](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/127021921/de1ec290-2334-4935-a0d9-711aaead893a)
### and Q40
![Screenshot from 2023-05-14 08-14-08](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/127021921/9ab871e4-d8fc-4448-b427-4a207a308a93)

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
