### PR TITLE
Update Q17 no escape char html-quiz.md

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -181,7 +181,7 @@
 - [x] C
 
 ```html
-<img src="cubism.jpg" alt='Version of "Whistler\'s Mother" in cubist style'>
+<img src="cubism.jpg" alt='Version of "Whistler&apos;s Mother" in cubist style'>
 ```
 
 - [ ] D


### PR DESCRIPTION
In HTML there aren't any functioning escape slashes. If we have a single and a double quote inside of a string we will need to use character codes to avoid issues. 

Before: none of the answers worked (put it in HTML to test)
After: one of the answers is correct

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
