### PR TITLE
Updated linux-assessment.md. Corrected the (&) sign in Q45.

### DIFF
--- a/linux/linux-assessment.md
+++ b/linux/linux-assessment.md
@@ -358,7 +358,7 @@ date | mail -s "This is a remote test" user1@rhhost1.localnet.com
 #### Q45. What would this sed command do?
 
 ```bash
-sed -E 's/[a-Z]{4}/($)/'  textfile.txt
+sed -E 's/[a-Z]{4}/(&)/'  textfile.txt
 ```
 
 - [ ] It would substitute the letter with an ampersand (&).


### PR DESCRIPTION
In Q45, there was a $ sign in the statement instead of &. So corrected the ampersand (&) sign used in the answers. The same question appeared in the LinkedIn assessment with an ampersand (&).

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
