### PR TITLE
Update after-effects-quiz.md

### DIFF
--- a/after-effects/after-effects-quiz.md
+++ b/after-effects/after-effects-quiz.md
@@ -62,7 +62,7 @@
 
 - [ ] Click Import As > Composition.
 - [ ] Click Import As > Footage.
-- [ ] Click Import As > Composition – Retain Layer Size.
+- [x] Click Import As > Composition – Retain Layer Size.
 - [ ] Set the PSD sequence option.
 
 #### Q10. How can you render a file in the background and keep working in After Effects?


### PR DESCRIPTION
Q9. An image was created on a transparent background in Photoshop using different dimensions to this After Effects composition. Which option was used when importing the PSD file shown below to place the image at its original scale and position?

Answer:- Import As > Composition – Retain Layer Size.

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [x] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements


