### PR TITLE
Update quickbooks-quiz.md

### DIFF
--- a/quickbooks/quickbooks-quiz.md
+++ b/quickbooks/quickbooks-quiz.md
@@ -77,7 +77,9 @@ https://www.chegg.com/homework-help/questions-and-answers/would-use-items-tab-en
 - [ ] You cannot change the basis for just one report.
 - [ ] Right-click the basis shown on the right side of the report and change it to Accrual.
 - [ ] Double-click the basis and change it to Accrual.
-- [ ] In the upper-left corner of the screen, select the Accrual button.
+- [x] In the upper-left corner of the screen, select the Accrual button.
+      
+- [Reference]In the upper-left corner of the screen, locate and select the Accrual button. This button is typically found in the toolbar or menu options. 
 
 #### Q12. Is it possible to merge two list entries?
 


### PR DESCRIPTION
Q11. You are running your Profit and Loss report and notice it is on a cash basis rather than an accrual basis. How can you correct this to show the correct basis?

- [ ] You cannot change the basis for just one report.
- [ ] Right-click the basis shown on the right side of the report and change it to Accrual.
- [ ] Double-click the basis and change it to Accrual.
- [x] In the upper-left corner of the screen, select the Accrual button.

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [x] I have added new quiz{'s}
- [x] I have added new reference link{'s}
- [x] I have made small correction/improvements


