### PR TITLE
Update NoSQL quiz - New question

### DIFF
--- a/nosql/nosql-quiz.md
+++ b/nosql/nosql-quiz.md
@@ -367,4 +367,11 @@ MATCH (t:Technology)-[:LIKES]-(a:Person {name: 'Jennifer'}) RETURN t.type;
 - [ ] a graph database
 - [ ] a ledger database
 
+#### Q49. Which command gets all documents in a MongoDB datastore where the status equals A or the quantity is less than 30?
+
+- [ ] db.inventory.find( { status: "a", qty: { $lt: 30 } } )
+- [x] db.inventory.find( { $or: [ { status: "A" }, { qty: { $lt: 30 } } ] } )
+- [ ] db.inventory.find( { status: "A", qty: { $lt: 30 } } )
+- [ ] db.inventory.find( { $or: [ { status: "a" }, { qty: { $lt: 30 } } ] } )
+
 [store and query JSON](https://aws.amazon.com/nosql/document/#:~:text=The%20document%20database%20defined,use%20in%20their%20application%20code.)


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [x] I have added new quiz question{'s}
- [x] I have added new reference link{'s}
- [x] I have made small corrections/improvements

### Changes / Instructions

Based on the given reference [link](https://www.mongodb.com/docs/manual/tutorial/query-documents/#specify-and-conditions), we can add the following question:
![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/68393093/988d1bb4-c3c1-4381-bc19-f22d7b38f5fa)

In fact, I had added this question as an [issue](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/issues/5642#issue-1667523881);

My explanation:
To solve this problem we'll need to be familiar with MongoDB's syntax for querying data. Specifically, we'll be dealing with conditional querying, where we want documents that fulfill one condition OR another. 

The correct answer is: `- [x] db.inventory.find( { $or: [ { status: "A" }, { qty: { $lt: 30 } } ] } )` --> the command will retrieve all documents in the `inventory` collection where the `status` is "A" OR `qty` is less than 30.

- `db.inventory.find()`: This is the method we use to query documents in MongoDB. We're attempting to find (query) from the `inventory` collection in the database (`db`).

- `{ $or: [ { status: "A" }, { qty: { $lt: 30 } } ] }`: This is the condition we're querying for. The `$or` operator inside the `{}` tells MongoDB to find documents where either of the provided conditions are met.

- `{ status: "A" }` is the first condition. It will match all documents where the `status` field is "A".

- `{ qty: { $lt: 30 } }` is the second condition. It will match all documents where the quantity (`qty`) is less than 30. Here, `$lt` is a comparison query operator provided by MongoDB that checks if a field is less than a specified value.

The other answers are wrong because:

- `db.inventory.find( { status: "a", qty: { $lt: 30 } } )`: This command will only find documents where `status` equals "a" AND `qty` is less than 30. Since we want documents if one or the other condition is true, not necessarily both, this command doesn't match the requirements.

- `db.inventory.find( { status: "A", qty: { $lt: 30 } } )`: Similar to the above, this command will only find documents where both conditions (`status` equals "A" AND `qty` is less than 30) are true, which doesn't match our requirement.

- `db.inventory.find( { $or: [ { status: "a" }, { qty: { $lt: 30 } } ] } )`: This command is right in most ways, but it searches for documents where `status` is "a" instead of "A". As MongoDB is case-sensitive, this is a different query than the required one.