### PR TITLE
Update bash-quiz.md

### DIFF
--- a/bash/bash-quiz.md
+++ b/bash/bash-quiz.md
@@ -1020,7 +1020,7 @@ echo "$VAR"
 
 - [ ] `<pre> This is... a string of characters</pre>`
 - [ ] `<pre> This is...a string of characters</pre>`
-- [ ] `<pre>This is... a string of characters</pre>`
+- [x] `<pre>This is... a string of characters</pre>`
 - [ ] `<pre>This is...a string of characters</pre>`
 
 References:


### PR DESCRIPTION
The script you provided enables extended globbing with `shopt -s extglob` and then attempts to trim the whitespace from the beginning and end of the VAR variable using parameter expansion combined with the extended globbing patterns.

Let's break down the commands:

1. `VAR=${VAR##+([[:space:]])}`:
This command trims the leading whitespaces.
  `##` trims from the start of the string.
  `+([[:space:]])` matches one or more whitespace characters.   
2. `VAR=${VAR%%+([[:space:]])}`:
This command trims the trailing whitespaces.
  `%%` trims from the end of the string.
  `+([[:space:]])` matches one or more whitespace characters.   
  
Given the initial value of VAR as ' This is... a string of characters ', after the trimming operations, the value would be:

`This is... a string of characters`

So, the correct output would be:

`<pre>This is...     a string of characters</pre>`

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
