### PR TITLE
fix: Q174 wrong word

### DIFF
--- a/python/python-quiz.md
+++ b/python/python-quiz.md
@@ -2497,7 +2497,7 @@ employees = {
 
 **Explanation:** This is accessing a key in a dictionary nested inside another dictionary. The command `employees['alice']['salary'] = employees['charlie']['salary']` assigns the value of the `salary` key in the dictionary of the employee `charlie` to the value of the `salary` key in the dictionary of the employee `alice`.
 
-#### Q174. You are given a piece of code. Assume `m` and `n` are already defined as some positive integer value. When it completes, how many tuples will my list contain?
+#### Q174. You are given this piece of code. Assume `m` and `n` are already defined as some positive integer value. When it completes, how many tuples will my list contain?
 
 ```python
 mylist = []


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

Just a correction of a word in the question
![Q174](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/102235852/28ee99d1-80cc-4bc7-ab35-a77e433116b7)
