### PR TITLE
Update c++-quiz.md

### DIFF
--- a/c++/c++-quiz.md
+++ b/c++/c++-quiz.md
@@ -36,10 +36,10 @@ typedef struct{
 }child_t;
 ```
 
-- [x] 7 bits.
+- [ ] 7 bits.
 - [ ] 25 bytes.
 - [ ] 1 bit.
-- [ ] 1 byte.
+- [x] 1 byte.
 
 [Reference](https://en.cppreference.com/w/cpp/language/bit_field)
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The size of a variable of type `child_t` is determined by the sum of the sizes of its bit fields, but it also depends on the underlying memory allocation policies of the compiler and the system architecture.

In the `child_t` structure, there are three bit fields: age with 4 bits, gender with 1 bit and size with 2 bits. The total size of these bit fields is 4 + 1 + 2 = 7 bits.

However, in memory, data is typically stored in bytes (8 bits). Therefore, even if the sum of the bit fields is 7 bits, the smallest storage size that a variable of type `child_t` can occupy in memory is normally rounded to the nearest byte, which is 8 bits.

So, in practice, the smallest size that a variable of type `child_t` can occupy in memory is normally 1 byte (8 bits).

That said, I changed the answer from 7 bits to 1 byte.