### PR TITLE
Update t-sql Q43 answer

### DIFF
--- a/t-sql/t-sql-quiz.md
+++ b/t-sql/t-sql-quiz.md
@@ -567,8 +567,8 @@ _______
 
 - [ ] `INDEX ON PersonID (PRIMARY KEY PK_People)`
 - [ ] `ADD NONCLUSTERED PRIMARY KEY CONSTRAINT PK_People ON PersonID`
-- [ ] `CONSTRAINT PK_People PRIMARY KEY NONCLUSTERED (PersonID)`
-- [x] `PRIMARY KEY CONSTRAINT (PersonID) NONCLUSTERED INDEX`
+- [x] `CONSTRAINT PK_People PRIMARY KEY NONCLUSTERED (PersonID)`
+- [ ] `PRIMARY KEY CONSTRAINT (PersonID) NONCLUSTERED INDEX`
 
 #### Q44. Which statement could you use to select a random student from this table?
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The syntax `PRIMARY KEY CONSTRAINT (PersonID) NONCLUSTERED INDEX` is not the correct way to define a primary key constraint with a nonclustered index in SQL.

The correct statement is to use the following syntax:
`CONSTRAINT PK_People PRIMARY KEY NONCLUSTERED (PersonID)`

In this statement, the primary key constraint is named `PK_People`, and it enforces uniqueness on the `PersonID` column with a nonclustered index.
