### PR TITLE
Update json Q20 answer

### DIFF
--- a/json/json-quiz.md
+++ b/json/json-quiz.md
@@ -327,8 +327,8 @@
 
 #### Q20. Which whitespace characters should be escaped within a string?
 
-- [ ] All whitespace is allowed.
-- [x] double quotes, slashes new lines, and carriage returns
+- [x] All whitespace is allowed.
+- [ ] double quotes, slashes new lines, and carriage returns
 - [ ] new lines and carriage returns only
 - [ ] double quotes only
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

This change must be approved after some discussion.

Here are my justifications for changing the answer.

The Question is asking: _Which **whitespace characters** should be escaped within a string?_
Double quotes (") are not considered whitespace characters, so by elimination the following answers are not valid.
- double quotes, slashes new lines, and carriage returns
- double quotes only

Which leads us to just two possible answers:
- all whitespace is allowed
- new lines and carriage returns only

Well, while it is generally good practice to escape whitespace characters for readability and to avoid potential problems with certain parsers, technically you can include newline characters (\n), carriage returns (\r), and others in a JSON string without escaping them and it will parse.

That being said, "All whitespace is allowed" should be the correct answer.

Any different thoughts?
