### PR TITLE
Fix Typo in Multiple-Choice Question Statement

### DIFF
--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -708,7 +708,7 @@ fmt.Println(i)
 Program exited.
 ```
 
-#### 45. Given the definition of worker below, what is the right syntax to start a start a goroutine that will call worker and send the result to a channel named ch?
+#### 45. Given the definition of worker below, what is the right syntax to start a goroutine that will call worker and send the result to a channel named ch?
 
 ```go
 func worker(m Message) Result


### PR DESCRIPTION
Removed redundant word 'start a' for clarity in question statement.

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
