### PR TITLE
Fix command for listing tags matching a pattern

### DIFF
--- a/git/git-quiz.md
+++ b/git/git-quiz.md
@@ -459,7 +459,7 @@ _note_: The question is not specific enough to give a definitive answer, as it d
 #### Q41. Which command will list tags with the 1.4.2 series?
 
 - [ ] git tag 'v1.4.2'
-- [x] git tag -I 'v1.4.2.\*'
+- [x] git tag -l 'v1.4.2.\*'
 - [ ] git tag-list 'v1.4.2\*'
 - [ ] git tag 'v1.4.2\*'
 


### PR DESCRIPTION
Small correction in `git tag -I 'v1.4.2.*'`: The option is -l, not -I
Reference: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt--l

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
