### PR TITLE
fix: typo in Go Q66 title

### DIFF
--- a/go/go-quiz.md
+++ b/go/go-quiz.md
@@ -1240,7 +1240,7 @@ x, err := myFunc()
 
 1. [Short variable declarations](https://go.dev/ref/spec#Short_variable_declarations)
 
-#### Q66. How can You view the profiler output in cpu.pprof in the broswer?
+#### Q66. How can You view the profiler output in cpu.pprof in the browser?
 
 - [ ] go pprof -to SVG cpu.prof
 - [x] go tool pprof -http=:8080 cpu.pprof (true)


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions
Fix typo `broswer` in Go Q66 title.
