### PR TITLE
fix: answer of HTML quiz Q5 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -30,8 +30,8 @@
 
 #### Q5. What is the best way to apply bold styling to text?
 
-- [x] `<strong>`
-- [ ] Use CSS.
+- [ ] `<strong>`
+- [x] Use CSS.
 - [ ] `<bold>`
 - [ ] `<b>`
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

In the HTML quiz question 5, an incorrect answer (i.e., `<strong>`) is given. 

According to MDN:
**`<strong>`** [**Source**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong#usage_notes)

The `<strong>` element is for content that is of "strong importance," including things of great seriousness or urgency (such as warnings). This could be a sentence that is of great importance to the whole page, or you could merely try to point out that some words are of greater importance compared to nearby content.

Typically this element is rendered by default using a bold font weight. However, it should not be used to apply bold styling; use the CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property for that purpose. 


**`<b>`** [**Source**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)

The `<b>` [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use `<b>` for styling text or granting importance. If you wish to create boldface text, you should use the CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property.

**`<bold>`** There's no such element in HTML.

Summing everything up, the correct answer is `Use CSS.`.

Thank you!