### PR TITLE
 fix: answer of HTML quiz Q13 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -134,10 +134,10 @@
 
 #### Q13. When should you use `<ol>` and `<ul>` elements?
 
-- [x] Use `<ul>` when you want a bulleted list and `<ol>` when you want a numbered list.
+- [ ] Use `<ul>` when you want a bulleted list and `<ol>` when you want a numbered list.
 - [ ] Use `<ul>` when you have a list of items in which the order of the items matters. Use `<ol>` when you have a list of items that could go in any order.
 - [ ] Use `<ol>` when you want a bulleted list and `<ul>` when you want a numbered list.
-- [ ] Use `<ol>` when you have a list of items in which the order of the items matters. Use `<ul>` when you have a list of items that could go in any order.
+- [x] Use `<ol>` when you have a list of items in which the order of the items matters. Use `<ul>` when you have a list of items that could go in any order.
 
 #### Q14. What is the difference between the post and get methods in a form?
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 13 is incorrect. According to MDN:

[**Source**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#usage_notes)

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/55214d30-44d4-4d3e-9bf9-3c20c5fe8edf)

The emphasis is the matter of order when comparing `<ul>` and `<ol>`. They (MDN) even provide an example of `<ol>` with a bullet list to make this clearer. That's so because we can always change the styling of lists with CSS `list-style` property. Try:

```html
<ol style="list-style: disc;">
    <li>a</li>
    <li>b</li>
    <li>c</li>
</ol>
```

Summing up, I believe that the given answer "_Use `<ul>` when you want a bulleted list and `<ol>` when you want a numbered list._" is incorrect and the correct answer is:

- [x] Use `<ol>` when you have a list of items in which the order of the items matters. Use `<ul>` when you have a list of items that could go in any order.


Thank you!
