### PR TITLE
fix: answer of HTML quiz Q20 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -255,9 +255,9 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 <a href="https://es.yahoo.com/" hreflang="____" target="_blank">Visita Yahoo</a>
 ```
 
-- [ ] es
+- [x] es
 - [ ] es-spanish
-- [x] es-es
+- [ ] es-es
 - [ ] spanish
 
 #### Q21. Review the text in the red box in the image shown. What is the best way to code this in HTML?


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 20 (i.e., `es-es`) is incorrect. According to MDN:

**[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#hreflang)**

`hreflang`
    Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as [the global lang attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang).


**[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#region_subtag)**
    
`lang`
### Language tag syntax
#### Region subtag

Optional. This subtag defines a dialect of the base language from a particular location, and is either 2 letters in ALLCAPS matching a country code, or 3 numbers matching a non-country area. For example, `es-ES` is for Spanish as spoken in Spain, and `es-013` is Spanish as spoken in Central America. "International Spanish" would just be `es`.


Summing everything up, the correct answer is just `es`.

Thank you!

