### PR TITLE
Fix typo in ruby on rails quiz

### DIFF
--- a/ruby-on-rails/ruby-on-rails-quiz.md
+++ b/ruby-on-rails/ruby-on-rails-quiz.md
@@ -485,7 +485,7 @@ end
 
 - [ ] The string assigned to flash[:notice] will not be available until the next browser request.
 - [ ] An instance variable should be used for flash[:notice]
-- [x] This is an invalid syntax to use to assign valuse to flash[:notice]
+- [x] This is an invalid syntax to use to assign values to flash[:notice]
 - [ ] The previous value of flash[:notice] will not be cleared automatically
       [Explanation]:
       The cause of the bug is a syntax error in the line that sets the value of the flash[:notice] message. The string literal "You have been logged out" is not properly enclosed in the surrounding string literal.


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

fix typo in Q40: `assign valuse to flash[:notice]` -> `assign values to flash[:notice]`