### PR TITLE
fix: answer of HTML quiz Q29 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -485,10 +485,10 @@ On July 21, 1969, Neil Armstrong said, "One small step for man, one giant leap f
 
 #### Q29. Which three tags were deprecated in HTML4 but returned to HTML5?
 
-- [x] `<rb> <rp> <rt>`
+- [ ] `<rb> <rp> <rt>`
 - [ ] `<acronym> <code> <wbr>`
 - [ ] `<hgroup> <q> <wbr>`
-- [ ] `<b> <i> <u>`
+- [x] `<b> <i> <u>`
 
 #### Q30. The **\_** tag is used for marking up a short code snippet, while the \_ tag is used for marking up a longer block of code
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 29 (i.e., "`<rb> <rp> <rt>`") is incorrect. 

[According to W3C](https://www.w3.org/TR/html5-diff/), `<ruby>`, `rt`, and `rp` are new elements introduced in HTML5, so these can't be returned to HTML5, automatically.

<details>
<summary>Click to view the screenshot</summary>
<img alt="Screenshot 2023-12-12 142259-1" src="https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/ffe93459-dcc7-4f50-900b-e2bf6dc5237d">
</details>

Similarly, the `<wbr>` element is a new element introduced in HTML5 too, so the answers `<hgroup> <q> <wbr>` and `<acronym> <code> <wbr>` can **NOT** be correct, too.

<details>
<summary>Click to view the screenshot</summary>
<img alt="Screenshot 2023-12-12 142259-2" src="https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/34217c37-bc8c-4a75-9225-39f21ca60574">
</details>

We are left with the only option, i.e.: `<b> <i> <u>`. So `<b> <i> <u>` should be the correct answer. To make this point stronger, I'd refer to MDN, again.

[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b#usage_notes)
```
Historically, the <b> element was meant to make text boldface. Styling information has been deprecated since HTML4, so the meaning of the <b> element has been changed.
```

[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u#usage_notes)
```
Along with other pure styling elements, the original HTML Underline (<u>) element was deprecated in HTML 4; however, <u> was restored in HTML 5 with a new, semantic, meaning: to mark text as having some form of non-textual annotation applied.
```

[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i#usage_notes)
```
In earlier versions of the HTML specification, the <i> element was merely a presentational element used to display text in italics, much like the <b> element was used to display text in bold letters. This is no longer true, as these tags now define semantics rather than typographic appearance. A browser will typically still display the contents of the <i> element in italic type, but is, by definition, no longer required to do so. To display text in italic type, authors should use the CSS [font-style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) property.
```

So, indeed `<b> <i> <u>` is the correct answer.

Thank you!