### PR TITLE
fix: answer of HTML quiz Q79 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1374,9 +1374,9 @@ As Steve Krug once said, happy talk must die.
 </details>
 ```
 
-- [x] A
+- [ ] A
       ![A](images/Q84-1.jpg)
-- [ ] B
+- [x] B
       ![B](images/Q84-2.jpg)
 - [ ] C
       ![C](images/Q84-3.jpg)


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 79 is incorrect. 

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details):

```
A <details> widget can be in one of two states. The default closed state displays only the triangle and the label inside <summary> (or a [user agent](https://developer.mozilla.org/en-US/docs/Glossary/User_agent)-defined default string if no <summary>).
```

So, the default state is closed, and if there's no `<summary>` content, the user-agent will display its default string, which in most cases is "Details". 

<details>
<summary>Click to view the screenshot</summary>
<img alt="W3Schools Try it" src="https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/850aeb42-07ad-425f-8b5f-9e5bc5390a41">
</details>

So, the correct answer is option **B**:

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/b5df026f-050f-499b-ba23-4ec8bccbf9c6)

Thank you!


