### PR TITLE
fix: answer of HTML quiz Q93 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1552,7 +1552,7 @@ As Steve Krug once said, happy talk must die.
 <input type="radio" name="example" /> Choice 3
 ```
 
-- [x] :
+- [ ] :
 
 ```HTML
 <input type="checkbox" name="example" /> Choice 1 <br />
@@ -1560,7 +1560,7 @@ As Steve Krug once said, happy talk must die.
 <input type="checkbox" name="example" /> Choice 3
 ```
 
-- [ ] :
+- [x] :
 
 ```HTML
 <label><input type="checkbox" name="example" /> Choice 1</label><br />


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 93 is incorrect. When HTML is rendered using the given answer, the user is not able to check/uncheck the checkbox(es) using the textual labels. Plus, textual labels aren't standalone elements so must be included in a parent element, somehow.

Whereas, the 3rd option allows the user to click on the textual labels to check/uncheck the checkboxes (better UX), and avoids the problem mentioned above. 

So, the correct answer is:
```HTML
<label><input type="checkbox" name="example" /> Choice 1</label><br />
<label><input type="checkbox" name="example" /> Choice 2</label><br />
<label><input type="checkbox" name="example" /> Choice 3</label>
```

Thank you!