### PR TITLE
fix: answer of HTML quiz Q97 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1607,9 +1607,9 @@ As Steve Krug once said, happy talk must die.
 
 #### Q97. Which choice is a valid markup for a `<head>` element?
 
-- [ ] `<head class="Page Section Information" id="head"><title>Page Title</title></head>`
+- [x] `<head class="Page Section Information" id="head"><title>Page Title</title></head>`
 - [ ] `<head><title>Page Title</title> <img src="favicon.icon" alt=""></head>`
-- [x] `<head><title>Page Title</title> <data value="email">email@example.com</data></head>`
+- [ ] `<head><title>Page Title</title> <data value="email">email@example.com</data></head>`
 - [ ] `<head><title>Page Title</title><address>email@example.com</address></head>`
 
 `The <head> HTML element contains machine-readable information (metadata) about the document, like its title. The <data> tag is used to add a machine-readable translation of a given content.`


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 97 is incorrect.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)

```
The <head> HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets.

Note: <head> primarily holds information for machine processing, not human-readability. For human-visible information, like top-level headings and listed authors, see the <header> element.
```

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data):

```
The <data> HTML element links a given piece of content with a machine-readable translation. 
```

The `<data>` element is mostly used in lists, tables, etc (examples [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data), [WhatWG](https://html.spec.whatwg.org/#the-data-element)). Including it in the `<head>` element has no metadata-related meaning. Plus, the `<data>` element is not part of the so-called **_Metadata content_**. See https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#metadata_content, and instead, is part of the so-called **_Flow content_** that goes inside `<body>`.

Including `<address>` and `<img>` inside `<head>` has no meaning too. These two are part of the so-called **_Flow content_**, as well. 

We are left with the first option, that is: `<head class="Page Section Information" id="head"><title>Page Title</title></head>`. That's the correct answer, because:

- The `<head>` element supports the HTML global attributes, which include both class and id. [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head#attributes)
- The confusing title-cased value of the class attribute (i.e., `Page Section Information`) is totally fine because "The class global attribute is a space-separated list of the **case-sensitive** classes of the element.". [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class)

Thank you!

