### PR TITLE
fix: answer of HTML quiz Q106 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -1784,7 +1784,7 @@ As Steve Krug once said, happy talk must die.
 
 #### Q106. How would you mark up a header for a table row?
 
-- [x] A
+- [ ] A
 
 ```HTML
 <table>
@@ -1798,7 +1798,7 @@ As Steve Krug once said, happy talk must die.
 </table>
 ```
 
-- [ ] B
+- [x] B
 
 ```HTML
 <table>


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 106 is incorrect.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th):

```
The <th> HTML element defines a cell as the header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.
```

and 

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/312aafc3-686f-416c-86b1-f08ba344c854)

Plus, when we compare the options **A** and **B**, here's what we get in the browser:

**option A** (❌ **incorrect**)

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/0e797f8f-2e3a-4af6-893e-815f947093d9)

**options B** (✅ **correct**)

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/6d0ece61-61e7-4185-bc37-64c729c5f47e)

Summing up, the correct answer is option **B**:

```html
<table>
  <tr>
    <th scope="row">Header</th>
    <td>10</td>
    <td>18</td>
  </tr>
</table>
```

Thank you!

