### PR TITLE
fix: answer of HTML quiz Q123 is incorrect

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -2053,8 +2053,8 @@ A disabled fieldset is unusable and un-clickable. [Source](https://www.w3schools
 
 - [ ] `<video src="video.mp4" caption="video.vtt"></video>`
 - [ ] `<video src="video.mp4"><track caption="video.vtt" /></video>`
-- [ ] `<video src="video.mp4"><track default kind="captions" srclang="en" src="video.vtt" /></video>`
-- [x] `<video src="video.mp4"><caption default srclang="en" src="video.vtt" /></video>`
+- [x] `<video src="video.mp4"><track default kind="captions" srclang="en" src="video.vtt" /></video>`
+- [ ] `<video src="video.mp4"><caption default srclang="en" src="video.vtt" /></video>`
 
 [Source](https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video)
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

The answer to HTML quiz question 123 is incorrect. There's no `<caption>` element for the `<video>` element. The <caption> HTML element specifies the caption (or title) of a table. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track):

![image](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/assets/9617660/1de814b7-1c19-4a37-a9c2-798b376d14aa)

In the MDN example:

- The `kind` attribute is responsible for how the text track is meant to be used (e.g, captions, subtitles). [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#kind)
- The `default` attribute indicates the default track (there can be multiple). [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#default)
- The `srclang` attribute identifies the language of the track text data. [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#srclang)

And finally the `src` attribute points the address of the track (.vtt file). [Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track#src)

The correct answer is the 3rd option, i.e.: `<video src="video.mp4"><track default kind="captions" srclang="en" src="video.vtt" /></video>`.

Thank you!


