### PR TITLE
fix: remove redundant '###' in option 4 Q26 of nosql-quiz.md

### DIFF
--- a/nosql/nosql-quiz.md
+++ b/nosql/nosql-quiz.md
@@ -180,7 +180,7 @@
 - [ ] Neo4j
 - [ ] Cassandra
 - [x] Redis
-- [ ] MyS#### QL
+- [ ] MySQL
 
 #### Q27. SQL databases and NoSQL are which types of scalable?
 


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [x] I have made small correction/improvements

### Changes / Instructions

- Correct option 4 of [Q26](https://github.com/Ebazhanov/linkedin-skill-assessments-quizzes/blob/main/nosql/nosql-quiz.md#q26-you-need-to-create-a-pubsub-server-which-database-do-you-use) from 'MyS#### QL' to 'MySQL', removing the extra # characters and space, as the correct name of the database referred to in this option is [MySQL](https://www.mysql.com/).
- Ensure the changes preserve the intended context of the questions and answers.