### PR TITLE
add multiple language version of angular quiz

### DIFF
--- a/angular/angular-quiz-ch.md
+++ b/angular/angular-quiz-ch.md
@@ -1,0 +1,1487 @@
+## Angular
+
+#### 问题1. 在这个组件类中，ViewChild 装饰器的作用是什么？
+
+```ts
+@Component({
+    ...
+    template: '<p #bio></p>'
+})
+export class UserDetailsComponent {
+    @ViewChild('bio') bio;
+}
+```
+
+- [x] 它提供了从组件类内部访问具有 bio 模板引用变量的 `<p>` 标签的 ElementRef 对象的能力。
+- [ ] 它表示 `<p>` 标签被渲染为使用此组件的父视图的子元素。
+- [ ] 它使模板中的 `<p>` 标签支持内容投影。
+- [ ] 它使 `<p>` 标签在最终渲染中可见。如果在模板中使用了 #bio 但在类中没有使用 @ViewChild，那么 Angular 会自动隐藏带有 #bio 的 `<p>` 标签。
+
+[DigitalOcean - viewchild-access-component](https://www.digitalocean.com/community/tutorials/angular-viewchild-access-component)
+
+#### 问题2. 在响应式表单中，使用什么方法将 FormControl 连接到原生 DOM input 元素？
+
+- [ ] 在 `<form>` 元素上添加一个名为 controls 的属性，并将 FormControl 的字符串名称赋给它，以指示应该包含哪些字段。
+- [ ] 在 DOM 元素的 value 属性周围使用方括号绑定语法，并将其设置为 FormControl 的实例。
+- [x] 使用 formControlName 指令，并将值设置为 FormControl 的字符串名称。
+- [ ] 使用 FormControl 的字符串名称作为 DOM 元素 id 属性的值。
+
+[Angular.io - Reactive Form Groups](https://angular.io/guide/reactive-forms#creating-nested-form-groups)
+
+#### 问题3. ActivatedRoute 类上的 `paramMap` 和 `queryParamMap` 有什么区别？
+
+- [ ] paramMap 是路由 URL 路径中参数的对象字面量。queryParamMap 是这些相同参数的 Observable。
+- [ ] paramMap 是一个包含路由 URL 路径中参数值的 Observable。queryParamMap 是一个接受键数组的方法，用于在 paramMap 中查找特定参数。
+- [ ] paramMap 是 Angular 3 的遗留名称。新名称是 queryParamMap。
+- [x] 两者都是包含请求路由 URL 字符串值的 Observable。paramMap 包含 URL 路径中的参数值，queryParamMap 包含 URL 查询参数。
+
+[StackOverflow](https://stackoverflow.com/a/49617621)
+
+#### 问题4. 基于以下 async 管道的使用，假设 users 类字段是一个 Observable，对 users Observable 进行了多少次订阅？
+
+```html
+<h2>姓名</h2>
+<div *ngFor="let user of users | async">{{ user.name }}</div>
+<h2>年龄</h2>
+<div *ngFor="let user of users | async">{{ user.age }}</div>
+<h2>性别</h2>
+<div *ngFor="let user of users | async">{{ user.gender }}</div>
+```
+
+- [ ] 没有。async 管道不会自动订阅。
+- [ ] 没有。模板语法不正确。
+- [x] 三次。每个 async 管道都有一次订阅。
+- [ ] 一次。async 管道在内部按类型缓存 Observable。
+
+[UltimateCourses](https://ultimatecourses.com/blog/angular-ngfor-async-pipe)
+
+#### 问题5. 如何在 OrderService 的 addOrder 函数中使用 HttpClient 向端点发送 POST 请求？
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  addOrder(order: Order) {
+    // 缺少的代码行
+  }
+}
+```
+
+- [ ] `this.httpClient.url(this.orderUrl).post(order);`
+- [ ] `this.httpClient.send(this.orderUrl, order);`
+- [ ] `this.httpClient.post<Order>(this.orderUrl, order);`
+- [x] `this.httpClient.post<Order>(this.orderUrl, order).subscribe();`
+
+[Angular.io - Sending data to server](https://angular.io/guide/http#sending-data-to-a-server)
+
+#### 问题6. RouterModule.forRoot 方法用于什么？
+
+- [ ] 注册您打算在路由组件中使用的任何提供者。
+- [x] 在根应用程序级别注册路由定义。
+- [ ] 指示 Angular 应该为您的路由的成功加油。
+- [ ] 声明您打算仅在根级别使用路由。
+
+[O'REILLY](https://www.oreilly.com/library/view/switching-to-angular/9781788620703/c9e90774-0e10-410b-bd20-d3e9e0b8d117.xhtml)
+
+#### 问题7. 此组件元数据选择器将匹配哪些 DOM 元素？
+
+```ts
+@Component({
+    selector: 'app-user-card',
+    . . .
+})
+```
+
+- [ ] 任何具有 app-user-card 属性的元素，例如 `<div app-user-card></div>`。
+- [ ] `<app-user-card></app-user-card>` 的第一个实例。
+- [x] `<app-user-card></app-user-card>` 的所有实例。
+- [ ] `<user-card></user-card>` 的所有实例。
+
+[Angular.io - Component Metadata](https://angular.io/guide/architecture-components#component-metadata)
+
+#### 问题8. 使用内置的 ngFor 结构指令渲染 productNames 列表的正确模板语法是什么？
+
+- [ ] A
+
+  ```html
+  <ul>
+    <li [ngFor]="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] B
+
+  ```html
+  <ul>
+    <li ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [x] C
+
+  ```html
+  <ul>
+    <li *ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] D
+
+  ```html
+  <ul>
+    <? for productName in productNames { ?>
+    <li>{{ productName }}</li>
+    <? } ?>
+  </ul>
+  ```
+
+[Angular.io- Structural Directives](https://angular.io/guide/built-in-directives#listing-items-with-ngfor)
+
+#### 问题9. 用于为组件设置 CSS 样式的两个组件装饰器元数据属性是什么？
+
+- [ ] viewEncapsulation 和 viewEncapsulationFiles。
+- [ ] 只有一个，它是名为 css 的属性。
+- [ ] css 和 cssUrl。
+- [x] styles 和 styleUrls。
+
+[Angular.io - Component Styles](https://angular.io/guide/component-styles)
+
+#### 问题10. 对于以下组件类，您将在模板中使用什么模板语法来显示 title 类字段的值？
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '',
+})
+class TitleCardComponent {
+  title = 'User Data';
+}
+```
+
+- [ ] `{{ 'title' }}`
+- [x] `{{ title }}`
+- [ ] `[title]`
+- [ ] 类字段无法通过模板语法在模板中显示。
+
+[Angular.io - String Interpolation or Text Interpolation](https://angular.io/guide/interpolation)
+
+#### 问题11. FormControl 上的 valueChanges 方法的目的是什么？
+
+- [ ] 它用于配置控件允许的值。
+- [ ] 它用于将控件的值更改为新值。您可以调用该方法并传入表单字段的新值。它甚至支持传入可以随时间设置的值数组。
+- [ ] 它根据控件的值是否与初始化时的值不同返回一个布尔值。
+- [x] 它是一个 observable，每次控件值更改时都会发出，因此您可以响应新值并在那时做出逻辑决策。
+
+[Angular.io - Displaying a from control value](https://angular.io/guide/reactive-forms#displaying-a-form-control-value)
+
+#### 问题12. 使用什么指令将 `<a>` 标签链接到路由？
+
+- [ ] routeTo
+- [x] routerLink
+- [ ] routePath
+- [ ] appLink
+
+[Angular.io - RouterLink](https://angular.io/api/router/RouterLink#description)
+
+#### 问题13. 在此组件类中，Output 装饰器用于什么？
+
+```ts
+@Component({
+    selector: 'app-shopping-cart',
+    . . .
+})
+export class ShoppingCartComponent {
+    @Output() itemTotalChanged = new EventEmitter();
+}
+```
+
+- [ ] 它使 `itemTotalChanged` 类字段成为公共的。
+- [ ] 它提供了一种将值绑定到 `itemTotalChanged` 类字段的方法，如：`<app-shopping-cart [itemTotalChanged]="newTotal"></app-shopping-cart>`。
+- [x] 它提供了一种将事件绑定到 `itemTotalChanged` 类字段的方法，如：`<app-shopping-cart (itemTotalChanged)="logNewTotal($event)"></app-shopping-cart>`。
+- [ ] 它只是在类字段前面放置注释以进行文档记录的一种方式。
+
+[Angular.io - Sending data to parent component](https://angular.io/guide/inputs-outputs#sending-data-to-a-parent-component)
+
+#### 问题14. 这两个标记示例在条件处理显示方面有什么区别？
+
+```html
+<div *ngIf="isVisible">Active</div>
+<div [hidden]="!isVisible">Active</div>
+```
+
+- [ ] `ngIf` 是另一个示例的简写。当 Angular 处理该指令时，它会向 DOM 写入一个具有 hidden 属性的 div 元素。
+- [ ] 它们基本上是相同的。
+- [x] 如果表达式为 false，`ngIf` 指令不会在 DOM 中渲染 div。`hidden` 属性用法在浏览器视口中隐藏 div 内容，但 div 仍然在 DOM 中。
+- [ ] `ngIf` 是有效的，但 `hidden` 属性的使用是错误的，会抛出错误。
+
+[StackOverflow](https://stackoverflow.com/a/39778145)
+
+#### 问题15. 在这个模板驱动表单示例中，当表单有错误时，如何禁用提交按钮？
+
+```html
+<form #userForm="ngForm">
+  <input type="text" ngModel name="firstName" required />
+  <input type="text" ngModel name="lastName" required />
+  <button (click)="submit(userForm.value)">Save</button>
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <button (click)="submit(userForm.value)" disable="userForm.invalid">Save</button>
+  ```
+
+- [x] B
+
+  ```html
+  <button (click)="submit(userForm.value)" [disabled]="userForm.invalid">Save</button>
+  ```
+
+- [ ] C
+
+  ```html
+  <button (click)="submit(userForm.value)" [ngForm.disabled]="userForm.valid">Save</button>
+  ```
+
+- [ ] D
+
+  ```html
+  <button (click)="submit(userForm.value)" *ngIf="userForm.valid">Save</button>
+  ```
+
+[Angular.io - Submit the form with ngSubmit](https://angular.io/guide/forms#submit-the-form-with-ngsubmit)
+
+#### 问题16. 您想查看创建新的 contact-card 组件会生成哪些文件。您会使用哪个命令？
+
+- [x] ng generate component contact-card --dry-run
+- [ ] ng generate component contact-card --no-files
+- [ ] ng generate component component --dry
+- [ ] ng generate component --exclude
+
+[Angular.io - ng generate options](https://angular.io/cli/generate#options)
+
+#### 问题17. 基于以下组件，您将使用什么模板语法将 TitleCardComponent 的 titleText 字段绑定到 h1 元素的 title 属性？
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '<h1 title="User Data"> {{titleText}}</h1>',
+})
+export class TitleCardComponent {
+  titleText = 'User Data';
+}
+```
+
+- [ ] `<h1 data-title="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 title="titleText">{{ titleText }}</h1>`
+- [x] `<h1 [title]="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 titleText>{{ titleText }}</h1>`
+
+[Angular.io - String Interpolation](https://angular.io/guide/interpolation)
+
+#### 问题18. 什么是 Angular 生命周期钩子？
+
+- [ ] 用于跟踪 Angular 应用程序健康状况的日志记录器
+- [ ] 可用于跟踪组件实例的提供者
+- [ ] 可在模板中用于 DOM 事件的内置管道
+- [x] 为组件和指令保留的命名方法，Angular 会在其执行的设定时间调用这些方法，可用于挖掘这些生命周期时刻
+
+[Angular.io - Lifecycle hooks](https://angular.io/guide/lifecycle-hooks)
+
+#### 问题19. 为此模板语法代码选择最佳描述：
+
+```html
+<span>Boss: {{job?.bossName}} </span>
+```
+
+- [ ] ? 是 async 管道的简写。job 值必须是 Observable。
+- [x] 它在 job 字段上使用安全导航操作符（?）。如果 job 字段未定义，对 bossName 的访问将被忽略，不会发生错误。
+- [ ] 模板语法中有错误。? 在这里无效。
+- [ ] 如果它有值，它会显示 job 值；否则它会显示 bossName。
+
+[StackOverflow](https://stackoverflow.com/a/60182134)
+
+#### 问题20. 您如何配置支持 URL 路径 user/23（其中 23 表示请求用户的 id）的 UserDetailComponent 的路由定义？
+
+- [x] `{ path: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ url: 'user/:id', routedComponent: UserDetailComponent }`
+- [ ] `{ routedPath: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ destination: new UserDetailComponent(), route: 'user/:id' }`
+
+[CodeCraft - Parameterised Routes](https://codecraft.tv/courses/angular/routing/parameterised-routes/#_configuration)
+
+#### 问题21. 此指令中的 HostListener 装饰器和 HostBinding 装饰器在做什么？
+
+```ts
+@Directive({
+  selector: '[appCallout]',
+})
+export class CalloutDirective {
+  @HostBinding('style.font-weight') fontWeight = 'normal';
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    this.fontWeight = 'bold';
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.fontWeight = 'normal';
+  }
+}
+```
+
+- [x] 它们根据鼠标是否悬停在 DOM 元素上来设置 CalloutDirective.fontWeight 字段。然后 HostListener 将 font-weight CSS 属性设置为 fontWeight 值。
+- [ ] 它们正在设置指令以检查它所在的 DOM 元素。如果它为鼠标进入和离开添加了事件绑定，它将使用此代码。否则，什么都不会发生。
+- [ ] 这是 HostListener 和 HostBinding 的错误用法。HostListener 和 HostBinding 装饰器在指令上不执行任何操作；它们仅在组件上使用时才起作用。
+- [ ] 如果此指令所在的 DOM 元素设置了 CSS 属性 font-weight，则会引发 mouseenter 和 mouseleave 事件。
+
+[DigitalOcean](https://www.digitalocean.com/community/tutorials/angular-hostbinding-hostlistener)
+
+#### 问题22. 在此模板驱动表单字段上，您可以使用什么 Angular 模板语法来访问字段值并在模板标记中检查验证？
+
+```html
+<input type="text" ngModel name="firstName" required minlength="4" />
+<span *ngIf="">Invalid field data</span>
+```
+
+- [x] 您可以使用模板引用变量和 ngModel 指令具有的 exportAs 功能。
+- [ ] 您可以将 ngModel 指令与输入字段名称结合使用。
+- [ ] 您可以为 HTML input 元素使用模板引用变量，然后检查其 valid 属性。
+- [ ] 使用模板驱动表单无法访问字段值。您必须为此使用响应式表单。
+
+1. [Angular.io -Show and hide validation error ](https://angular.io/guide/forms#show-and-hide-validation-error-messages)
+2. [Medium](https://medium.com/@agoiabeladeyemi/template-driven-forms-in-angular-4a3a5ad960de)
+
+#### 问题23. 在此标记中，headerText 模板引用变量将存储什么值类型？
+
+```html
+<h1 #headerText>User List</h1>
+```
+
+- [x] Angular ElementRef，原生元素的包装器
+- [ ] `<h1>` 元素的内部文本
+- [ ] header 组件类
+- [ ] 原生 DOM 元素类型 HTMLHeadingElement
+
+[Pluralsight - Template reference variable](https://www.pluralsight.com/guides/how-to-use-template-reference-variables-in-angular)
+
+#### 问题24. 基于这两个提供者配置，结果代码逻辑有什么区别（如果有的话）？
+
+```ts
+[{ provide: FormattedLogger, useClass: Logger }][{ provide: FormattedLogger, useExisting: Logger }];
+```
+
+- [ ] 它们是相同的。两者都将导致绑定到 FormattedLogger 令牌的 Logger 新实例。
+- [x] useClass 语法告诉注入器创建 Logger 的新实例并将该实例绑定到 FormattedLogger 令牌。useExisting 语法引用已声明为 Logger 的现有对象实例。
+- [ ] 两者都是错误的。强类型不能用于 useClass 或 useExisting。
+- [ ] 它们是相同的。两者都将导致 FormattedLogger 令牌成为 Logger 实例的别名。
+
+1. [Angular.io - Dependency Providers](https://angular.io/guide/dependency-injection-providers#defining-providers)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-providers/)
+
+#### 问题25. 路由配置中的 data 属性（如下例所示）的目的是什么？
+
+```ts
+   {
+       path: 'customers',
+       component: CustomerListComponent,
+       data: { accountSection: true }
+   }
+```
+
+- [ ] 用于在路由组件实例上设置 @Input 值的键/值映射
+- [x] 一种包含与路由关联的静态只读数据的方法，可以从 ActivatedRoute 检索
+- [ ] 路由上的属性，可用于为路由加载动态数据
+- [ ] 一个将自动注入到路由组件构造函数中的对象。
+
+1. [TektutorialsHub](https://www.tektutorialshub.com/angular/angular-pass-data-to-route/#:~:text=Angular%20allows%20us%20to%20pass,of%20the%20history%20state%20object)
+2. [StackOverflow](https://stackoverflow.com/a/36835156)
+
+#### 问题26. 基于此模板语法，内置的 `ngIf` 结构指令如何更改渲染的 DOM？
+
+```ts
+@Component({
+  selector: 'app-product',
+  template: '<div *ngIf="product">{{ product.name }}</div>',
+})
+export class ProductComponent {
+  @Input() product;
+}
+```
+
+- [ ] `<div>` 充当占位符。如果 product 类字段为"真值"，`<div>` 将被仅 `product.name` 值替换；如果不是，则不会渲染任何内容。
+- [ ] `<div>` 将始终被渲染，如果 product 字段为"真值"，`<div>` 元素将包含 `product.name` 值；否则，它将渲染没有值的 `<div>` 元素。
+- [ ] 它会产生错误，因为 ngIf 不是内置的结构指令。
+- [x] 如果 product 类字段为"真值"，则渲染的 DOM 将包含带有 `product.name` 字段值的 `<div>`。如果不是"真值"，渲染的 DOM 将不包含 `<div>` 元素。
+
+[Reference (angular.io)](https://angular.io/api/common/NgIf)
+
+#### 问题27. 这段代码完成了什么？
+
+```ts
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic().bootstrapModule(AppModule);
+```
+
+- [ ] 它为 NgModule 执行单元测试。
+- [ ] 它提供了一种编写 Angular 应用程序文档结构的方法。@NgModule 是一种内联代码注释形式，被 TypeScript 编译器忽略，但会在代码编辑器应用程序中以特殊格式显示。
+- [ ] 它声明了一个名为 AppModule 的 Angular 模块，并使其在整个应用程序中可用于延迟加载。
+- [x] 它声明了一个名为 AppModule 的 Angular 模块，其中包含一个名为 AppComponent 的引导组件。然后它将该模块注册到 Angular，以便应用程序可以启动。
+
+[Angular.io - The basic NgModule](https://angular.io/guide/ngmodules#the-basic-ngmodule)
+
+#### 问题28. 在此路由配置中，_resolve_ 属性的作用是什么？
+
+```ts
+{
+   path: ':id',
+   component: UserComponent,
+   resolve: {
+     user: UserResolverService
+   }
+}
+```
+
+- [x] 在加载 _UserComponent_ 之前，路由器将订阅 _UserResolverService_ 中 _resolve_ 方法返回的 _Observable_。此技术可用于获取 _route_ 的预加载数据。
+- [ ] 在 _route_ 完成解析后，组件被加载并渲染，_UserResolverService_ 将运行一个名为 _user_ 的方法，该方法将清理任何打开的数据连接。
+- [ ] 有错误。正确的属性名称是 _onResolve_。
+- [ ] _UserComponent_ 的构造函数中将有一个 _user_ 参数，_router_ 将处理从 _UserResolverService_ 中的 _user_ 方法调用注入该值。
+
+[angular.io](https://angular.io/api/router/Resolve)
+
+#### 问题29. 在此组件类中，ContentChildren 装饰器的目的是什么？
+
+```ts
+@Component({
+ . . .
+ template: '<ng-content></ng-content>'
+})
+export class TabsListComponent {
+ @ContentChildren(TabComponent) tabs;
+}
+```
+
+- [ ] 如果将任何 _TabsComponent_ 元素添加到 _TabsListComponent_ 模板，它们将在运行时被放入 `<ng-content>` 元素中。
+- [ ] 当 _TabsListComponent_ 实例化时，它会在 _TabsListComponent_ 模板中创建 _TabComponent_ 组件。
+- [x] 它提供了从组件类内部访问已内容投影到此组件的 `<ng-content>` 中的任何 _TabComponent_ 组件的能力。
+- [ ] 它限制可以放入 _TabsListComponent_ 元素的允许元素，只允许 _TabComponent_ 元素。
+
+[betterprogramming.pub](https://betterprogramming.pub/understanding-contentchildren-with-an-example-e76ce78968db)
+
+#### 问题30. 为了让 Angular 处理应用程序中的组件，组件类型需要在哪里注册？
+
+- [ ] 在 index.html 文件的 script 标签中
+- [ ] 在名为 _components_ 的 NgModule 装饰器元数据标签中
+- [ ] 不需要注册，只需将组件文件包含在 app 目录中即可。
+- [x] 在名为 _declarations_ 的 NgModule 装饰器元数据属性中
+
+[angular.io](https://angular.io/guide/ngmodule-api#ngmodule-metadata)
+
+#### 问题31. 在此单元测试中，`fixture.detectChanges()` 调用的目的是什么？
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+
+fixture.detectChanges();
+
+expect(fixture.nativeElement.querySelector('h1').textContent).toContain(
+  fixture.componentInstance.title,
+);
+```
+
+- [ ] 它跟踪任何潜在的 UI 更改，如果进行了任何更改，将使单元测试失败。
+- [ ] 它用于确保整个测试套件中多个单元测试的组件模板稳定性。
+- [x] 它强制 Angular 执行变更检测，这将在您验证模板之前渲染 _UserCardComponent_。
+- [ ] 它用于在单元测试运行期间将变更检测事件记录到控制台。
+
+[angular.io](https://angular.io/api/core/testing/ComponentFixture#detectChanges)
+
+#### 问题32. 当 goToUser 传递值 15 时，基于以下对 `Router.navigate` 方法的调用，URL 段将是什么样子？
+
+```ts
+export class ToolsComponent {
+  constructor(private router: Router) {}
+  goToUser(id: number) {
+    this.router.navigate(['user', id]);
+  }
+}
+```
+
+- [x] /user/15
+- [ ] /user?id=15
+- [ ] /user:15
+- [ ] /user;id=15
+
+[angular.io](https://angular.io/api/router/Router#navigate)
+
+#### 问题33. 当为 root 提供服务并且还将其添加到延迟加载模块的提供者配置时，注入器向延迟加载模块中的构造函数提供该服务的什么实例？
+
+- [x] 当模块延迟加载时，将创建该服务的新实例。
+- [ ] 不允许在延迟加载的模块级别提供相同类型的服务。
+- [ ] 如果尚未在根级别创建服务实例，它将在那里创建一个，然后使用它。
+- [ ] 该服务的单个实例始终在根处实例化，并且是唯一使用的实例，包括在延迟模块中。
+
+#### 问题34. 此指令中的 HostBinding 装饰器在做什么？
+
+```ts
+@Directive({
+  selector: ' [appHighlight] ',
+})
+export class HighlightDirective {
+  @HostBinding('class.highlighted') highlight = true;
+}
+```
+
+- [x] 它将名为 highlighted 的 CSS 类添加到任何具有 appHighlight 指令的 DOM 元素。
+- [ ] HostBinding 在指令上不执行任何操作，仅在组件上执行。
+- [ ] 它指定如果宿主元素的 class 属性添加了 highlighted 类，则指令类字段 highlight 将设置为 true；如果未在宿主上添加，它将设置为 false。
+- [ ] 它在宿主元素上创建内联样式，CSS 属性名为 highlight，设置为 true。
+
+[StackOverflow](https://stackoverflow.com/a/46207423)
+
+#### 问题35. 在响应式表单中，在原生 DOM `<form>` 元素上使用什么 Angular 表单类类型来连接它？
+
+- [ ] `FormArray`
+- [ ] `FormControl`
+- [x] `FormGroup`
+- [ ] `所有这些答案`
+
+#### 问题36. 假设 username FormControl 已配置了 minLength 验证器，您如何在以下响应式表单标记中为 username 字段设置错误显示？
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  ...
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <span *ngIf="username.minLength.invalid"> Username length is not valid </span>
+  ```
+
+- [ ] B
+
+  ```html
+  <input type="text" formControlName="username" [showMinLength]="true" />
+  ```
+
+- [ ] C
+
+  ```html
+  <span *ngIf="form.get('username').getError('minLength') as minLengthError">
+    Username must be at least {{ minLengthError.requiredLength }} characters.
+  </span>
+  ```
+
+- [x] D
+
+  ```html
+  <input type="text" formControlName="username" #userName="ngModel" />
+  <span *ngIf="userName.errors.minlength">
+    Username must be at least {{ userName.errors.minlength.requiredLength }} characters.
+  </span>
+  ```
+
+[Codecraft](https://codecraft.tv/courses/angular/forms/template-driven/)
+
+#### 问题37. 仿真视图封装模式如何处理组件的 CSS？
+
+- [ ] 它完全按照您编写的方式渲染 CSS，无需任何更改。
+- [ ] 它使用 shadow DOM 标记和 CSS。
+- [x] 它为 DOM 元素创建唯一属性，并将您编写的 CSS 选择器范围限定到这些属性 ID。
+- [ ] 它将您编写的所有 CSS 规则渲染为在模板中使用的所有 DOM 元素上的内联 CSS。
+
+[Angular.io](https://angular.io/guide/view-encapsulation#inspecting-generated-css)
+
+#### 问题38. 使用以下 TestBed 设置，可以使用什么来访问 UserCardComponent 的渲染 DOM？
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+```
+
+- [ ] `fixture.componentTemplate`
+- [ ] `fixture.getComponentHtml()`
+- [x] `fixture.nativeElement`
+- [ ] `fixture.componentInstance.template `
+
+1. [StackOverflow](https://stackoverflow.com/a/56504773)
+2. [Angular.io](https://angular.io/guide/testing-components-basics#nativeelement)
+
+#### 问题39. 给定这两个组件，基于标记用法，将向 DOM 渲染什么？
+
+```ts
+@Component({
+ selector: 'app-card',
+ template: '<h1>Data Card</h1><ng-content></ng-content>'
+})
+export class CardComponent { }
+
+@Component({
+ selector: 'app-bio',
+ template: '<ng-content></ng-content>.
+})
+export class BioComponent { }
+
+// 标记用法：
+<app-card><app-bio>Been around for four years.</app-bio></app-card>
+```
+
+- [x] A
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+    <app-bio>
+      Been around for four years.
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Data Card</h1>
+  <app-bio> Been around for four years. </app-bio>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+    <ng-content></ng-content>
+    <app-bio>
+      Been around for four years.
+      <ng-content></ng-content>
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+  </app-card>
+  ```
+
+#### 问题40. 给定下面代码中的 app-title-card 组件，app-user-card 组件将渲染什么 DOM？
+
+```ts
+@Component({
+   selector: 'app-user-card',
+   template: '<app-title-card></app-title-card><p>Jenny Smith</p>'
+})
+
+@Component({
+   selector: 'app-title-card',
+   template: '<h1>User Data</hl>'
+})
+
+// 在父组件 html 中使用 user card 组件
+<app-user-card></app-user-card>
+```
+
+- [x] A
+
+  ```html
+  <app-user-card>
+    <app-title-card>
+      <h1>User Data</h1>
+    </app-title-card>
+    <p>Jenny Smith</p>
+  </app-user-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>User Data</h1>
+  <p>Jenny Smith</p>
+  <p></p>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-user-card>
+    <app-title-card></app-title-card>
+  </app-user-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <div app-user-card>
+    <h1 app-title-card>User Data</h1>
+    <p>Jenny Smith</p>
+  </div>
+  ```
+
+#### 问题41. 为 @Inject() 装饰器正在寻找的自定义提供者注册选择匹配的代码：
+
+```ts
+constructor(@Inject('Logger') private logger) { }
+```
+
+- [ ] A
+
+  ```ts
+  providers: [Logger];
+  ```
+
+- [x] B
+
+  ```ts
+  providers: [{ provide: 'Logger', useClass: Logger }];
+  ```
+
+- [ ] C
+
+  ```ts
+  @Injectable({
+      providedln: 'root'
+  })
+  ```
+
+- [ ] D
+
+  ```ts
+  providers: [{ provide: 'Logger' }];
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/37315355)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-injector-injectable-inject/)
+3. [Angular.io - Dependency Injection In Action](https://angular.io/guide/dependency-injection-in-action#supply-a-custom-provider-with-inject)
+
+#### 问题42. 在 getsettings 类方法中，以下 HttpClient.get 方法的使用描述最准确的是哪个？
+
+```ts
+export class SettingsService {
+    constructor(private httpClient: HttpClient) { }
+    ...
+
+getSettings()
+{
+    return this.httpClient.get<Settings>(this.settingsUrl)
+        .pipe(
+            retry(3)
+        );
+}}
+```
+
+- [ ] RxJs pipe 方法是 subscribe 方法的别名，因此对 `getSettings` 的调用将执行 get 查询。retry 操作符用于告诉 pipe 调用重试 get 查询三次。
+- [ ] 它将在运行时产生错误，因为 pipe 方法在 `Httpclient.get` 调用之后不可用。
+- [ ] 每次调用 getSettings 方法都将导致 Httpclient 向 settingsUrl 发出总共三次 get 请求，这并不理想，因为总会有两次额外的不需要的调用。不应以这种方式使用 retry 操作符。
+- [x] 当订阅 getSettings 方法的结果时，将进行 HTTP GET 调用；如果失败，它将在放弃并返回错误之前重试最多三次。
+
+1. [learnrxjs.io](https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retry)
+2. [dev.to](https://dev.to/gparlakov/how-does-rxjs-retry-work-412p)
+
+#### 问题43. 当服务需要通过方法进行一些设置以初始化其默认状态时，如何确保在服务被注入到任何地方之前调用该方法？
+
+- [ ] 将该服务方法的逻辑放入服务构造函数中。
+- [x] 在根 AppModule 级别使用依赖于服务的工厂提供者来调用该服务方法。
+- [ ] 无法在应用程序启动时执行此操作；您只能在组件级别执行此操作。
+- [ ] 在全局级别（window 范围）实例化服务实例，然后调用该方法。
+
+1. [Angular.io](https://angular.io/guide/dependency-injection-providers)
+2. [Stackoverflow](https://stackoverflow.com/questions/39803876/how-to-use-factory-provider)
+
+#### 问题44. 哪个语句最能描述 TestBed 的这种用法？
+
+```ts
+const spy = jasmine.createSpyObj('DataService', ['getUsersFromApi']);
+TestBed.configureTestingModule({
+  providers: [UserService, { provide: DataService, useValue: spy }],
+});
+const userService = TestBed.get(UserService);
+```
+
+- [ ] 每当您想在 Angular 提供者的单元测试中使用 spy 对象时，都需要 TestBed。
+- [ ] TestBed 正在用于测试组件的视图。
+- [x] TestBed 使用两个提供者搭建 NgModule 并处理任何依赖注入。如果任何 Angular 类在其构造函数中请求 DataService，TestBed 将在该构造函数中注入 spy。
+- [ ] TestBed 正在配置测试运行器，以告诉它仅执行其 providers 数组中列出的两个提供者的测试。
+
+`所有其他测试都将被忽略，包括针对这些提供者之一和未定义提供者进行断言的测试。`
+`尽管在单个测试中针对此配置中的多个提供者进行断言时它会起作用。`
+
+#### 问题45. 组件和指令之间的主要区别是什么？
+
+- [ ] 组件使用选择器元数据属性，而指令不使用。
+- [ ] 指令可用于向 DOM 添加自定义事件，而组件不能。
+- [x] 组件有模板，而指令没有。
+- [ ] 指令只能针对原生 DOM 元素。
+
+[StackOverflow](https://stackoverflow.com/a/34616190)
+
+#### 问题46. 您可以向此指令类添加什么以允许在标记中使用指令时设置截断长度？
+
+```ts
+@Directive({
+    selector: '[appTruncate]'
+})
+export class TruncateDirective {
+    . . .
+}
+
+// 期望用法示例：
+<p [appTruncate]="10">Some very long text here</p>
+```
+
+- [x] `@Input() appTruncate: number;`
+- [ ] `@Output() appTruncate;`
+- [ ] `constructor(maxLength: number) { }`
+- [ ] `无。指令选择器不能用于将值传递给指令。`
+
+1. [Angular.io](https://angular.io/guide/attribute-directives#passing-values-into-an-attribute-directive)
+2. [StackOverflow](https://stackoverflow.com/a/46303049)
+
+#### 问题47. 如何将查询参数传递给此 `HttpClient.get` 请求？
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  getOrdersByYear(year: number): Observable<Order[]> {
+    return this.httpClient.get<Order[]>(this.ordersUrl);
+  }
+}
+```
+
+- [ ] A `return this.httpClient.get<Order[]>(this.ordersUrl, {'year': year})`
+- [ ] B `return this.httpClient.get<Order[]>(this.ordersUrl, year)`
+- [x] C
+
+  ```ts
+  const options = { params: new HttpParams().set('year', year) };
+  return this.httpClient.get<Order[]>(this.ordersUrl, options);
+  ```
+
+- [ ] D
+
+  ```ts
+  getOrdersByYear(year: number): Observable<Order[]> {
+      return this.httpClient.addParam('year', year).get<Order[]>(this.ordersUrl, year);
+  }
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/34475594)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-pass-url-parameters-query-strings/#httpparams)
+
+#### 问题48. 假设 `DataService` 已在应用程序的提供者中注册，基于此组件的构造函数，哪个答案最能描述会发生什么？
+
+```ts
+@Component({
+    ...
+})
+export class OrderHistoryComponent {
+    constructor(private dataService: DataService) {}
+    ...
+}
+```
+
+- [ ] 它声明 `OrderHistoryComponent` 将拥有自己的 `DataService` 版本，并且永远不应使用任何现有实例。`DataService` 需要在类中实例化为私有字段，此代码才能完整且正常工作。
+- [x] 当 Angular 创建 `OrderHistoryComponent` 的新实例时，注入器将向组件构造函数的第一个参数提供 `DataService` 类的实例。构造函数的 `dataService` 参数将用于在实例上设置同名的私有实例字段。
+- [ ] 它提供了一种仅进行组件测试的方法；构造函数在 Angular 应用程序的实际运行中没有用途。
+- [ ] 它使组件目标的自定义元素具有名为 `dataService` 的自定义属性，可用于绑定现有的 `DataService` 实例。
+
+1. [StackOverflow](https://stackoverflow.com/a/49755822)
+2. [Angular.io - Dependency Injection](https://angular.io/guide/dependency-injection)
+
+#### 问题49. 使用 `ngIf` 指令完成此标记以实现 else 情况，该情况将显示文本"User is not active"：
+
+```html
+<div *ngIf="userIsActive; else inactive">Currently active!</div>
+```
+
+- [ ] A
+
+  ```html
+  <div #inactive>User is not active.</div>
+  ```
+
+- [ ] B
+
+  ```html
+  <div *ngIf="inactive">User is not active.</div>
+  ```
+
+- [ ] C
+
+  ```html
+  <ng-template #else="inactive">
+    <div>User is not active.</div>
+  </ng-template>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-template #inactive>
+    <div>User is not active.</div>
+  </ng-template>
+  ```
+
+[Angular.io](https://angular.io/api/common/NgIf)
+
+#### 问题50. 延迟加载功能模块的路由定义的正确语法是什么？
+
+- [ ] A
+
+  ```ts
+  {
+    path: 'users',
+    lazy: './users/users.module#UsersModule'
+  }
+  ```
+
+- [x] B
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: () => import('./users/users.module').then(m => m.UserModule)
+  }
+  ```
+
+- [ ] C
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: './users/users.module#UsersModule'
+  }
+  ```
+
+- [ ] D
+
+  ```ts
+  {
+    path: 'users',
+    module: UsersModule
+  }
+  ```
+
+[Angular.io - Lazy Loading Modules](https://angular.io/guide/lazy-loading-ngmodules)
+
+#### 问题51. 描述此响应式表单示例中如何设置和配置验证：
+
+```ts
+export class UserFormControl implements OnInit {
+    ...
+    ngOnInit() {
+        this.form = this.formBuilder.group({
+            username: this.formBuilder.control('',
+                [Validators.required, Validators.minLength(5), this.unique]),
+        )};
+    }
+    unique(control: FormControl) {
+        return control.value !== 'admin' ? null: {notUnique: true};
+    }
+}
+```
+
+- [ ] `username` 的 `FormControl` 正在配置为从允许使用的验证器中排除三个验证器。
+- [ ] `username` 的 `FormControl` 正在配置为允许使用三个可能的验证器：`required, maxLength` 和名为 `unique` 的自定义验证器。要启用这些 `validators`，需要在标记的表单字段上放置验证器指令。
+- [ ] 无法以这种方式在响应式表单中设置验证。
+- [x] `username` 的 `FormControl` 正在配置三个验证器：来自 Angular 的 `required` 和 `minLength` 验证器，以及名为 `unique` 的自定义验证器函数，该函数检查值不等于字符串 `admin`。
+
+1. [Angular.io - Form Validation](https://angular.io/guide/form-validation)
+2. [Angular University Blog](https://blog.angular-university.io/angular-custom-validators/)
+
+#### 问题52. Injectable 装饰器在此服务类上做什么？
+
+```ts
+@Injectable({
+    providedIn: 'root'
+)}
+export class DataService { }
+```
+
+- [ ] 它为服务注册一个提供者，该提供者仅在根模块级别可用，而不适用于任何子模块。
+- [x] 它在根应用程序注入器中为服务注册一个提供者，使其单个实例在整个应用程序中可用。
+- [ ] 它使服务只能在应用程序的引导组件中注入。
+- [ ] 它设置了一个编译时规则，允许您仅将服务类型放在根 NgModule 的 providers 元数据属性中。
+
+[Angular.io](https://angular.io/guide/providers#providing-a-service)
+
+#### 问题53. 描述此代码的用法
+
+```ts
+export interface AppSettings {
+  title: string;
+  version: number;
+}
+export const APP_SETTINGS = new InjectionToken<AppSettings>('app.settings');
+```
+
+- [ ] InjectionToken 通过 InjectionToken 构造函数调用将 AppSettings 的实例添加到根提供者，使其在整个 Angular 应用程序中自动可用于所有 NgModules、服务和组件，而无需在任何地方注入它。
+- [x] InjectionToken 用于为非类依赖项创建提供者令牌。对象字面量可以作为 APP_SETTINGS 依赖提供者类型的值提供，然后可以注入到组件、服务等中。
+- [ ] InjectionToken 用于为 AppSettings 创建动态装饰器，可以通过 @AppSettings 装饰器在构造函数参数上使用。
+- [ ] 此代码有错误，因为您不能在 InjectionToken 上使用 TypeScript 接口作为泛型类型
+
+#### 问题54. 对于以下模板驱动表单示例，可以将什么参数传递给点击事件中的 submit 方法以提交表单数据？
+
+```html
+<form #form="ngForm">
+  <input type="text" ngModel="firstName" /> <input type="text" ngModel="lastName" />
+  <button (click)="submit()">Save</button>
+</form>
+```
+
+- [x] submit(form.value)
+- [ ] submit($event)
+- [ ] submit(ngForm.value)
+- [ ] submit(FirstName, lastName)
+
+#### 问题55. 此路由器代码中 `prelodingStrategy` 属性配置的目的是什么？
+
+```ts
+RouterModule.forRoot(
+  ...{
+    preloadingStrategy: PreloadAllModules,
+  },
+);
+```
+
+- [ ] 它启用了标记单个路由进行预加载的选项。
+- [ ] 它预加载路由的所有依赖项，在应用程序首次启动时创建服务实例
+- [ ] 它确保所有模块都构建到单个应用程序模块包文件中。
+- [x] 它配置路由器立即加载具有 loadChildren 属性的所有路由（通常在请求时加载的路由）
+
+参考：
+
+- [Angular Router, PreloadAllModules](https://angular.io/api/router/PreloadAllModules)
+- [Route preloading in Angular](https://web.dev/route-preloading-in-angular/)
+- [Preloading strategy](https://www.tektutorialshub.com/angular/angular-preloading-strategy/)
+- [Custom preloading strategy](https://www.concretepage.com/angular-2/angular-custom-preloading-strategy#Preloading)
+- [Preloading strategy, save loading time](https://medium.com/geekculture/preloading-strategy-in-angularsave-loading-time-ca791074fe28)
+
+#### 问题56. 编写此标记以将类字段 `userName` 的值绑定到 `h1` 元素 title 属性的替代方法是什么？
+
+```html
+<h1 [title]="userName">Current user is {{ userName }}</h1>
+```
+
+- [ ] `title="userName"`
+- [x] `title="{{ userName }}"`
+- [ ] `title="{{ 'userName' }}"`
+- [ ] 唯一的方法是使用方括号。
+
+#### 问题57. 在此示例中，`async` 管道在做什么？
+
+```ts
+@Component({
+  selector: 'app-users',
+  template: '<div *ngFor="let user of users | async">{{ user.name }}</div>',
+})
+export class UsersComponent implements OnInit {
+  users;
+  constructor(private httpClient: HttpClient) {}
+  ngOnInit(): void {
+    this.users = this.httpClient.get<{ name: string }>('users');
+  }
+}
+```
+
+- [ ] 它什么都不做，因为 async 管道不能在 `ngFor` 语句中使用。
+- [ ] 它配置 `ngFor` 迭代以同时支持多个用户列表。
+- [x] 它订阅从 `HttpClient.get` 方法返回的 observable，并解包返回的值，以便可以在 `ngFor` 中进行迭代。
+- [ ] 它允许 `users` 字段中的所有用户同时渲染到 DOM。
+
+#### 问题58. 基于其选择器值，您将如何在标记中使用此指令
+
+```ts
+@Directive({  selector: '[appTruncate]'
+})
+export class TruncateDirective{  . . .
+}
+```
+
+- [ ] `html <p data-directive="appTruncate">Some long text </p> `
+- [x] `html <p appTruncate>Some long text</p> `
+- [ ] `html <p app-truncate>Some long text</p> `
+- [ ] `html <app-truncate>Some long text</app-truncate> `
+
+#### 问题59. 可以在组件上使用什么生命周期钩子来监视该组件上所有 @Input 值的所有更改？
+
+- [ ] ngOnInit
+- [ ] ngChanges
+- [ ] ngAfterInputChange
+- [x] ngOnChanges
+
+[How to detect when an @Input() value changes in Angular?](https://stackoverflow.com/a/44686085/1573267)
+
+#### 问题60. 此自定义管道的模板语法用法示例是什么？
+
+```ts
+@Pipe({ name: 'truncate' })
+export class TruncatePipe implements PipeTransform {
+  transform(value: string, maxLength: number, showEllipsis: boolean) {
+    const newValue = maxLength ? value.substr(0, maxLength) : value;
+    return showEllipsis ? '${newValue}...' : newValue;
+  }
+}
+```
+
+- [ ] `{{ 'some long text' | truncate:10 }}`
+- [x] `{{ 'some long text' | truncate: 10, true }}`
+- [ ] `{{ 'some long text' | truncate }}`
+- [ ] 所有这些答案
+
+[How do I call an Angular 2 pipe with multiple arguments?] (https://stackoverflow.com/questions/36816788/how-do-i-call-an-angular-2-pipe-with-multiple-arguments)
+
+#### 问题61. 您将运行哪个 Angular CLI 命令来生成 UsersComponent 并将其添加到 SharedModule（在应用程序的 shared.module.ts 文件中）？
+
+- [ ] ng generate component --newModule=shared
+- [x] ng generate component users --module=shared
+- [ ] ng generate component users --shared
+- [ ] ng generate component --add=shared
+
+#### 问题62. 如何重写此标记，以便在最终 DOM 渲染中不需要 div 容器
+
+```html
+<div *ngIf="location">
+  <h1>{{ location.name }}</h1>
+  <p>{{ location.description }}</p>
+</div>
+```
+
+- [ ] A
+
+  ```html
+  <div *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+    {{ endNgIf }}
+  </div>
+  ```
+
+- [ ] B
+
+  ```html
+  <ng-template *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-template>
+  ```
+
+- [ ] C
+
+  ```html
+  <div *ngIf="location" [display]=" ' hidden' ">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </div>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-container *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-container>
+  ```
+
+#### 问题63. 如何使用模板语法将名为 tabWidth 的组件类字段绑定到此元素上的内联样式 width CSS 属性？
+
+<div class="tab"></div>
+
+- [ ] <code>{{ width: tabWidth }}</code>
+- [ ] [width]="tabWidth"
+- [ ] [inline.width]="tabWidth"
+- [x] [style.width.px]="tabWidth"
+
+#### 问题64. 对没有构造函数依赖项的服务进行单元测试需要哪些 Angular 实用程序（如果有）？
+
+- [ ] 需要 By.css() 辅助方法
+- [ ] 需要文本 fixture 才能为单元测试运行服务。
+- [ ] 无。可以自行实例化服务并进行单元测试。
+- [x] 需要 TestBed 类来实例化服务。
+
+[Angular unit tests](https://angular.io/guide/testing-services) - 重新检查答案
+
+#### 问题65. CanActivate 和 CanLoad 路由守卫之间有什么区别？
+
+- [ ] CanActivate 用于检查访问权限。CanLoad 用于为路由预加载数据。
+- [ ] CanLoad 在应用程序启动时使用，以允许或拒绝将路由添加到路由表。CanActivate 用于在请求路由时管理对路由的访问。
+- [ ] CanActivate 和 CanLoad 完全做同样的事情。
+- [x] CanLoad 防止整个 NgModule 被交付和加载。CanActivate 停止路由到该 NgModule 中的组件，但该模块仍然被加载。
+
+[CanActivate vs Canload](https://stackoverflow.com/questions/42026045/difference-between-angulars-canload-and-canactivate#:~:text=canActivate%20is%20used%20to%20prevent,not%20authorized%20to%20do%20so.) CanActivate 阻止访问路由，CanLoad 阻止延迟加载。
+
+#### 问题66. 在此路由器定义对象中，outlet 属性用于什么？
+
+```ts
+{  path: 'document',  component: DocumentComponent,  outlet: 'document-box'
+}
+```
+
+- [ ] 它将定位 DOM 中所有 `<document-box>` 的实例，并在路由导航时将 DocumentComponent 元素插入其中。
+- [ ] 它声明 DocumentComponent 除了可以路由到之外，还可以用作 `<document-box>` 元素的子元素。
+- [x] 它用于以 name 属性与字符串值匹配的 `<router-outlet>` 元素为目标，作为路由到时渲染 DocumentComponent 的位置。
+- [ ] 它是路由器的动力源。（绝对不是答案 :P）
+
+[Angular-outlet](https://angular.io/api/router/RouterOutlet) - 重新检查答案
+
+#### 问题67. 在此模板语法中，每次更改 items 属性（添加、删除等）时，ngFor 结构指令都会为循环中的所有 DOM 元素重新运行其逻辑。可以使用什么语法使其更高效？
+
+```html
+<div *ngFor="let item of items">{{ item.id }} - {{ item.name }}</div>
+```
+
+- [ ] `*ngFor="let item of items; let uniqueItem"`
+- [ ] `*ngFor="let item of items.distinct()"`
+- [ ] `*ngFor="let item of items: let i = index"`
+- [x] `*ngFor="let item of items; trackBy: trackById"`
+
+[StackOverflow - How to use `trackBy` with `ngFor`](https://stackoverflow.com/a/58025894)
+
+#### 问题68. 此 Angular CLI 命令做什么？
+
+```bash
+ng build --configuration=production --progress=false
+```
+
+- [ ] 它构建 Angular 应用程序，将构建配置设置为 angular.json 文件中指定的"production"目标，并将进度输出记录到控制台。
+- [ ] 它构建 Angular 应用程序，将构建配置设置为 angular.json 文件中指定的"production"目标，并监视文件的更改。
+- [ ] 它构建 Angular 应用程序，将构建配置设置为 angular.json 文件中指定的"production"目标，并禁用监视文件的更改。
+- [x] 它构建 Angular 应用程序，将构建配置设置为 angular.json 文件中指定的"production"目标，并阻止进度输出到控制台。
+
+[Angular documentation - `ng build`](https://angular.io/cli/build#:~:text=%2D%2D-,progress,-Log%20progress%20to)
+
+#### 问题69. 服务类可以通过哪些装饰器注册为提供者？
+
+- [ ] @Injectable, @NgModule, @Component 和 @Directive。
+- [x] 仅 @Injectable。
+- [ ] 仅 @Injectable 和 @NgModule。
+- [ ] 仅 @Service 和 @NgModule。
+
+#### 问题70. 在此组件类中，Input 装饰器用于什么？
+
+```ts
+@Component({  selector:'app-product-name',  ...
+})
+export class ProductNameComponent {  @Input() productName: string
+}
+```
+
+- [ ] 它只是用于在类字段前面放置注释以进行文档记录。
+- [x] 它提供了一种通过使用组件选择器将值绑定到 productName 字段的方法。
+- [ ] 它在组件模板中自动生成 `html
+<input type='text' id='productName'>` Dom 元素。
+- [ ] 它提供了一种将值绑定到 productName 实例字段的方法，就像原生 DOM 元素属性绑定一样。
+      [Angular documentation - `Input()`](https://angular.io/guide/inputs-outputs)
+
+#### 问题71. 哪个路由守卫可用于调解导航到路由？
+
+- [x] 所有这些答案。
+- [ ] CanDeactivate。
+- [ ] CanLoad
+- [ ] CanActivate。
+      [Angular documentation - `Input()`](https://angular.io/guide/inputs-outputs)
+
+#### 问题72. 如何配置注入器使用现有对象作为令牌，而不是让它实例化类实例？
+
+- [x] 使用 `useValue` 提供者配置，并将其设置为现有对象或对象字面量。
+- [ ] 不可能。提供者只能配置类类型。
+- [ ] 只需将对象实例或字面量添加到提供者的数组中。
+- [ ] 使用 `asValue` 提供者配置属性，将其设置为 true。
+
+[Configuring dependency providers](https://angular.io/guide/dependency-injection-providers)
+
+#### 问题73. 基于此路由定义，可以将什么注入到 UserDetailComponent 构造函数中以获取 id 路由参数？
+
+```ts
+{path: 'user/:id', component: UserDetailComponent }
+```
+
+- [x] ActivatedRoute
+- [ ] CurrentRoute
+- [ ] UrlPath
+- [ ] @Inject('id')
+
+[Common Routing Tasks](https://angular.io/guide/router#observable-parammap-and-component-reuse)
+
+#### 问题74. 使用以下响应式表单标记，您将添加什么来连接对 onSubmit 类方法的调用？
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  <button type="submit" [disabled]="form. invalid">Submit</button>
+</form>
+```
+
+- [ ] 这两个答案都不是
+- [ ] 将 (click)="onSubmit()" 添加到 `<button>` 元素。
+- [x] 将 (ngSubmit )="onSubmit ()" 添加到 `<form>` 元素。
+- [ ] 这两个答案都是
+
+[Angular - Forms](https://angular.io/guide/forms)
+
+#### 问题75. 当 isActive 为 true 时，ngClass 属性指令的这种用法的预期 DOM 代码是什么？
+
+```html
+<div [ngClass]="{ 'active-item': isActive }">Item One</div>
+```
+
+- [ ] `<div active-item>Item One</div>`
+- [x] `<div class="active-item">Item One</div>`
+- [ ] `<div class="is-active">Item One</div>`
+- [ ] `<div class="active-item isActive">Item One</div>`
+
+[Angular - NgClass](https://angular.io/api/common/NgClass)
+
+#### 问题76. 哪个答案最能解释此模板代码中 ngModel 的用法？
+
+```html
+<input [(ngModel)]="user.name" />
+```
+
+- [ ] 如果 user.name 属性有值，它会有条件地显示 input 元素。
+- [x] 它是双向数据绑定语法。input 元素 value 属性将绑定到 user.name 属性，表单元素的 value change 事件将更新 user.name 属性值。
+- [ ] 代码中有错字。它应该只有方括号。
+- [ ] 它将 user.name 属性的值绑定到 input 元素的 val 属性以设置其初始值。
+
+[Angular - NgModel](https://angular.io/api/forms/NgModel)
+
+#### 问题77. NgModules 可以包含在其他 NgModules 中。您应该使用哪个代码示例在 SharedModule 中包含 TableModule？
+
+- [ ] @NgModule({
+      exports: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [x] @NgModule({
+      imports: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [ ] @NgModule({
+      declarations: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [ ] @NgModule({
+      providers: [TableModule]
+      })
+      export class SharedModule {}
+
+#### 问题78. 可以使用什么其他模板语法（替换 ngClass 指令）在此标记中添加或删除 CSS 类名？
+
+```html
+<span [ngClass]="{ 'active': isActive, 'can-toggle': canToggle }"> Employed </span>
+```
+
+- [ ] A
+
+  ```html
+  <span class="{{ isActive ? 'is-active' : '' }} {{ canToggle ? 'can-toggle' : '' }}">
+    Employed
+  </span>
+  ```
+
+- [x] B
+
+  ```html
+  <span [class.active]="isActive" [class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+- [ ] C
+
+  ```html
+  <span [styles.class.active]="isActive" [styles.class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+- [ ] D
+
+  ```html
+  <span [css.class.active]="isActive" [css.class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+#### 问题79. 在此指令装饰器示例中，提供者对象字面量中的 multi 属性的目的是什么？
+
+```ts
+@Directive({
+  selector: '[customValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CustomValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class CustomValidatorDirective implements Validator {}
+```
+
+- [ ] 它表示 CustomValidatorDirective 可用于多种表单元素类型。
+- [ ] 它允许实例化 CustomValidatorDirective 的多个实例。如果没有 multi，CustomValidatorDirective 将是整个应用程序的单例。
+- [x] 它允许为单个 NG_VALIDATORS 令牌注册不同的提供者。在这种情况下，它将 CustomValidatorDirective 添加到可用的表单验证器列表中。
+- [ ] 它表示将有多个类处理自定义验证器的逻辑实现。
+
+[StackOverflow](https://stackoverflow.com/questions/38144641/what-is-multi-provider-in-angular2)
+
+#### 问题80. 您将使用哪个 Angular CLI 命令来运行单元测试，该过程会在文件更改时重新运行测试套件？
+
+- [ ] ng test --single-run=false
+- [ ] ng test --watch-files
+- [ ] ng test --progress
+- [x] ng test
+
+#### 问题81. ngOnDestory 生命周期钩子最常见的用途是什么？
+
+- [ ] 从组件视图中删除 dom 元素
+- [ ] 删除任何注入的服务
+- [x] 取消订阅 observables 并分离
+- [ ] 以上所有
+
+#### 问题82. 利用什么 NgModule 装饰器元数据属性来允许其他....？
+
+- [ ] public
+- [ ] experts
+- [ ] Shared
+- [x] declarations
+
+#### 问题83. 使用以下组件类，您将在模板中使用什么模板语法来显示调用 currentYear 类函数的结果？
+
+```ts
+@Component({
+  selector: 'app-date-card',
+  template: '',
+})
+export class DateCardComponent {
+  currentYear() {
+    return new Date().getFullYear();
+  }
+}
+```
+
+- [x] `{% raw %}{{ currentYear() }}{% endraw %}`
+- [ ] `{% raw %}{{ component.currentYear() }}{% endraw %}`
+- [ ] `{% raw %}{{ currentYear }}{% endraw %}`
+- [ ] 不能从模板语法调用类函数。

--- a/angular/angular-quiz-de.md
+++ b/angular/angular-quiz-de.md
@@ -1,0 +1,1484 @@
+## Angular
+
+#### F1. Was ist der Zweck des ViewChild-Dekorators in dieser Komponentenklasse?
+
+```ts
+@Component({
+    ...
+    template: '<p #bio></p>'
+})
+export class UserDetailsComponent {
+    @ViewChild('bio') bio;
+}
+```
+
+- [x] Er bietet Zugriff von innerhalb der Komponentenklasse auf das ElementRef-Objekt für das `<p>`-Tag, das die bio-Template-Referenzvariable in der Template-Ansicht der Komponente hat.
+- [ ] Er zeigt an, dass das `<p>`-Tag als Kind der übergeordneten Ansicht gerendert wird, die diese Komponente verwendet.
+- [ ] Er ermöglicht es dem `<p>`-Tag im Template, Content Projection zu unterstützen.
+- [ ] Er macht das `<p>`-Tag im finalen Rendering sichtbar. Wenn #bio im Template verwendet wurde und @ViewChild nicht in der Klasse verwendet wurde, würde Angular das `<p>`-Tag mit #bio automatisch verbergen.
+
+[DigitalOcean - viewchild-access-component](https://www.digitalocean.com/community/tutorials/angular-viewchild-access-component)
+
+#### F2. Welche Methode wird verwendet, um ein FormControl in reaktiven Formularen mit einem nativen DOM-Eingabeelement zu verbinden?
+
+- [ ] Fügen Sie den String-Namen, der dem FormControl gegeben wurde, einem Attribut namens controls auf dem `<form>`-Element hinzu, um anzugeben, welche Felder es enthalten soll.
+- [ ] Verwenden Sie die eckige Klammer-Binding-Syntax um das value-Attribut auf dem DOM-Element und setzen Sie dies gleich einer Instanz des FormControl.
+- [x] Verwenden Sie die formControlName-Direktive und setzen Sie den Wert gleich dem String-Namen, der dem FormControl gegeben wurde.
+- [ ] Verwenden Sie den String-Namen, der dem FormControl gegeben wurde, als Wert für das id-Attribut des DOM-Elements.
+
+[Angular.io - Reactive Form Groups](https://angular.io/guide/reactive-forms#creating-nested-form-groups)
+
+#### F3. Was ist der Unterschied zwischen `paramMap` und `queryParamMap` in der `ActivatedRoute`-Klasse?
+
+- [ ] Die paramMap ist ein Objekt-Literal der Parameter im URL-Pfad einer Route. Die queryParamMap ist ein Observable dieser gleichen Parameter.
+- [ ] Die paramMap ist ein Observable, das die Parameterwerte enthält, die Teil des URL-Pfads einer Route sind. Die queryParamMap ist eine Methode, die ein Array von Schlüsseln entgegennimmt und verwendet wird, um bestimmte Parameter in der paramMap zu finden.
+- [ ] paramMap ist der Legacy-Name aus Angular 3. Der neue Name ist queryParamMap.
+- [x] Beide sind Observables, die Werte aus dem angeforderten URL-String der Route enthalten. Die paramMap enthält die Parameterwerte, die im URL-Pfad sind, und die queryParamMap enthält die URL-Query-Parameter.
+
+[StackOverflow](https://stackoverflow.com/a/49617621)
+
+#### F4. Basierend auf der folgenden Verwendung der async-Pipe und unter der Annahme, dass das Klassenfeld users ein Observable ist, wie viele Subscriptions zum users-Observable werden erstellt?
+
+```html
+<h2>Namen</h2>
+<div *ngFor="let user of users | async">{{ user.name }}</div>
+<h2>Alter</h2>
+<div *ngFor="let user of users | async">{{ user.age }}</div>
+<h2>Geschlechter</h2>
+<div *ngFor="let user of users | async">{{ user.gender }}</div>
+```
+
+- [ ] Keine. Die async-Pipe abonniert nicht automatisch.
+- [ ] Keine. Die Template-Syntax ist nicht korrekt.
+- [x] Drei. Es gibt eine für jede async-Pipe.
+- [ ] Eine. Die async-Pipe cached Observables nach Typ intern.
+
+[UltimateCourses](https://ultimatecourses.com/blog/angular-ngfor-async-pipe)
+
+#### F5. Wie können Sie den HttpClient verwenden, um eine POST-Anfrage an einen Endpunkt aus einer addOrder-Funktion in diesem OrderService zu senden?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  addOrder(order: Order) {
+    // Fehlende Zeile
+  }
+}
+```
+
+- [ ] `this.httpClient.url(this.orderUrl).post(order);`
+- [ ] `this.httpClient.send(this.orderUrl, order);`
+- [ ] `this.httpClient.post<Order>(this.orderUrl, order);`
+- [x] `this.httpClient.post<Order>(this.orderUrl, order).subscribe();`
+
+[Angular.io - Daten an Server senden](https://angular.io/guide/http#sending-data-to-a-server)
+
+#### F6. Wofür wird die RouterModule.forRoot-Methode verwendet?
+
+- [ ] Zum Registrieren von Providern, die Sie in gerouteten Komponenten verwenden möchten.
+- [x] Zum Registrieren von Route-Definitionen auf der Root-Anwendungsebene.
+- [ ] Um anzuzeigen, dass Angular Ihre Routes zum Erfolg anfeuern soll.
+- [ ] Um zu deklarieren, dass Sie Routing nur auf der Root-Ebene verwenden möchten.
+
+[O'REILLY](https://www.oreilly.com/library/view/switching-to-angular/9781788620703/c9e90774-0e10-410b-bd20-d3e9e0b8d117.xhtml)
+
+#### F7. Welche DOM-Elemente werden mit diesem Komponenten-Metadaten-Selektor übereinstimmen?
+
+```ts
+@Component({
+    selector: 'app-user-card',
+    . . .
+})
+```
+
+- [ ] Jedes Element mit dem Attribut app-user-card, wie z.B. `<div app-user-card></div>`.
+- [ ] Die erste Instanz von `<app-user-card></app-user-card>`.
+- [x] Alle Instanzen von `<app-user-card></app-user-card>`.
+- [ ] Alle Instanzen von `<user-card></user-card>`.
+
+[Angular.io - Component Metadata](https://angular.io/guide/architecture-components#component-metadata)
+
+#### F8. Was ist die korrekte Template-Syntax für die Verwendung der eingebauten strukturellen ngFor-Direktive, um eine Liste von productNames zu rendern?
+
+- [ ] A
+
+  ```html
+  <ul>
+    <li [ngFor]="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] B
+
+  ```html
+  <ul>
+    <li ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [x] C
+
+  ```html
+  <ul>
+    <li *ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] D
+
+  ```html
+  <ul>
+    <? for productName in productNames { ?>
+    <li>{{ productName }}</li>
+    <? } ?>
+  </ul>
+  ```
+
+[Angular.io - Strukturelle Direktiven](https://angular.io/guide/built-in-directives#listing-items-with-ngfor)
+
+#### F9. Was sind die beiden Komponenten-Dekorator-Metadaten-Eigenschaften, die verwendet werden, um CSS-Stile für eine Komponente einzurichten?
+
+- [ ] viewEncapsulation und viewEncapsulationFiles.
+- [ ] Es gibt nur eine und das ist die Eigenschaft namens css.
+- [ ] css und cssUrl.
+- [x] styles und styleUrls.
+
+[Angular.io - Component Styles](https://angular.io/guide/component-styles)
+
+#### F10. Mit der folgenden Komponentenklasse, welche Template-Syntax würden Sie im Template verwenden, um den Wert des title-Klassenfelds anzuzeigen?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '',
+})
+class TitleCardComponent {
+  title = 'User Data';
+}
+```
+
+- [ ] `{{ 'title' }}`
+- [x] `{{ title }}`
+- [ ] `[title]`
+- [ ] Ein Klassenfeld kann nicht über die Template-Syntax in einem Template angezeigt werden.
+
+[Angular.io - String Interpolation oder Text Interpolation](https://angular.io/guide/interpolation)
+
+#### F11. Was ist der Zweck der valueChanges-Methode auf einem FormControl?
+
+- [ ] Sie wird verwendet, um zu konfigurieren, welche Werte für das Control erlaubt sind.
+- [ ] Sie wird verwendet, um den Wert eines Controls auf einen neuen Wert zu ändern. Sie würden diese Methode aufrufen und den neuen Wert für das Formularfeld übergeben. Sie unterstützt sogar das Übergeben eines Arrays von Werten, die im Laufe der Zeit gesetzt werden können.
+- [ ] Sie gibt einen Boolean zurück, basierend darauf, ob der Wert des Controls sich von dem Wert unterscheidet, mit dem es initialisiert wurde.
+- [x] Es ist ein Observable, das jedes Mal emittiert, wenn sich der Wert des Controls ändert, sodass Sie auf neue Werte reagieren und zu diesem Zeitpunkt logische Entscheidungen treffen können.
+
+[Angular.io - Anzeigen eines Formular-Control-Werts](https://angular.io/guide/reactive-forms#displaying-a-form-control-value)
+
+#### F12. Welche Direktive wird verwendet, um ein `<a>`-Tag mit Routing zu verknüpfen?
+
+- [ ] routeTo
+- [x] routerLink
+- [ ] routePath
+- [ ] appLink
+
+[Angular.io - RouterLink](https://angular.io/api/router/RouterLink#description)
+
+#### F13. Wofür wird der Output-Dekorator in dieser Komponentenklasse verwendet?
+
+```ts
+@Component({
+    selector: 'app-shopping-cart',
+    . . .
+})
+export class ShoppingCartComponent {
+    @Output() itemTotalChanged = new EventEmitter();
+}
+```
+
+- [ ] Es macht das `itemTotalChanged`-Klassenfeld öffentlich.
+- [ ] Es bietet eine Möglichkeit, Werte an das `itemTotalChanged`-Klassenfeld zu binden, so: `<app-shopping-cart [itemTotalChanged]="newTotal"></app-shopping-cart>`.
+- [x] Es bietet eine Möglichkeit, Ereignisse an das `itemTotalChanged`-Klassenfeld zu binden, so: `<app-shopping-cart (itemTotalChanged)="logNewTotal($event)"></app-shopping-cart>`.
+- [ ] Es ist einfach eine Möglichkeit, einen Kommentar vor ein Klassenfeld zur Dokumentation zu setzen.
+
+[Angular.io - Daten an übergeordnete Komponente senden](https://angular.io/guide/inputs-outputs#sending-data-to-a-parent-component)
+
+#### F14. Was ist der Unterschied zwischen diesen beiden Markup-Beispielen für die bedingte Handhabung der Anzeige?
+
+```html
+<div *ngIf="isVisible">Aktiv</div>
+<div [hidden]="!isVisible">Aktiv</div>
+```
+
+- [ ] Das `ngIf` ist eine Kurzform für das andere Beispiel. Wenn Angular diese Direktive verarbeitet, schreibt es ein div-Element in das DOM mit der hidden-Eigenschaft.
+- [ ] Sie sind grundsätzlich gleich.
+- [x] Die `ngIf`-Direktive rendert das div nicht im DOM, wenn der Ausdruck false ist. Die Verwendung der `hidden`-Eigenschaft verbirgt den div-Inhalt im Browser-Viewport, aber das div ist immer noch im DOM.
+- [ ] Das `ngIf` ist gültig, aber die Verwendung der `hidden`-Eigenschaft ist falsch und wird einen Fehler werfen.
+
+[StackOverflow](https://stackoverflow.com/a/39778145)
+
+#### F15. Wie können Sie den Submit-Button deaktivieren, wenn das Formular in diesem Template-getriebenen Formular-Beispiel Fehler hat?
+
+```html
+<form #userForm="ngForm">
+  <input type="text" ngModel name="firstName" required />
+  <input type="text" ngModel name="lastName" required />
+  <button (click)="submit(userForm.value)">Speichern</button>
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <button (click)="submit(userForm.value)" disable="userForm.invalid">Speichern</button>
+  ```
+
+- [x] B
+
+  ```html
+  <button (click)="submit(userForm.value)" [disabled]="userForm.invalid">Speichern</button>
+  ```
+
+- [ ] C
+
+  ```html
+  <button (click)="submit(userForm.value)" [ngForm.disabled]="userForm.valid">Speichern</button>
+  ```
+
+- [ ] D
+
+  ```html
+  <button (click)="submit(userForm.value)" *ngIf="userForm.valid">Speichern</button>
+  ```
+
+[Angular.io - Formular mit ngSubmit absenden](https://angular.io/guide/forms#submit-the-form-with-ngsubmit)
+
+#### F16. Welchen Angular CLI-Befehl würden Sie verwenden, um zu sehen, welche Dateien durch das Erstellen einer neuen contact-card-Komponente generiert würden?
+
+- [x] ng generate component contact-card --dry-run
+- [ ] ng generate component contact-card --no-files
+- [ ] ng generate component component --dry
+- [ ] ng generate component --exclude
+
+[Angular.io - ng generate Optionen](https://angular.io/cli/generate#options)
+
+#### F17. Basierend auf der folgenden Komponente, welche Template-Syntax würden Sie verwenden, um das titleText-Feld der TitleCardComponent an die title-Eigenschaft des h1-Elements zu binden?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '<h1 title="User Data"> {{titleText}}</h1>',
+})
+export class TitleCardComponent {
+  titleText = 'User Data';
+}
+```
+
+- [ ] `<h1 data-title="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 title="titleText">{{ titleText }}</h1>`
+- [x] `<h1 [title]="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 titleText>{{ titleText }}</h1>`
+
+[Angular.io - String Interpolation](https://angular.io/guide/interpolation)
+
+#### F18. Was sind Angular-Lifecycle-Hooks?
+
+- [ ] Logger zur Verfolgung der Gesundheit einer Angular-App
+- [ ] Provider, die verwendet werden können, um die Instanzen von Komponenten zu verfolgen
+- [ ] Eingebaute Pipes, die in Templates für DOM-Events verwendet werden können
+- [x] Reservierte benannte Methoden für Komponenten und Direktiven, die Angular während bestimmter Zeiten in seiner Ausführung aufruft und die verwendet werden können, um in diese Lifecycle-Momente einzutauchen
+
+[Angular.io - Lifecycle Hooks](https://angular.io/guide/lifecycle-hooks)
+
+#### F19. Wählen Sie die beste Beschreibung für diese Template-Syntax aus:
+
+```html
+<span>Chef: {{job?.bossName}} </span>
+```
+
+- [ ] Das ? ist eine Kurzform für die async-Pipe. Der job-Wert muss ein Observable sein.
+- [x] Es verwendet den Safe-Navigation-Operator (?) auf dem job-Feld. Wenn das job-Feld undefined ist, wird der Zugriff auf bossName ignoriert und es tritt kein Fehler auf.
+- [ ] Es gibt einen Fehler in der Template-Syntax. Das ? ist hier nicht gültig.
+- [ ] Es zeigt den job-Wert an, wenn er einen hat; andernfalls zeigt es den bossName an.
+
+[StackOverflow](https://stackoverflow.com/a/60182134)
+
+#### F20. Wie würden Sie eine Route-Definition für eine UserDetailComponent konfigurieren, die den URL-Pfad user/23 unterstützt (wobei 23 die ID des angeforderten Benutzers darstellt)?
+
+- [x] `{ path: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ url: 'user/:id', routedComponent: UserDetailComponent }`
+- [ ] `{ routedPath: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ destination: new UserDetailComponent(), route: 'user/:id' }`
+
+[CodeCraft - Parametrisierte Routes](https://codecraft.tv/courses/angular/routing/parameterised-routes/#_configuration)
+
+#### F21. Was machen die HostListener-Dekoratoren und der HostBinding-Dekorator in dieser Direktive?
+
+```ts
+@Directive({
+  selector: '[appCallout]',
+})
+export class CalloutDirective {
+  @HostBinding('style.font-weight') fontWeight = 'normal';
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    this.fontWeight = 'bold';
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.fontWeight = 'normal';
+  }
+}
+```
+
+- [x] Sie setzen das CalloutDirective.fontWeight-Feld basierend darauf, ob die Maus über dem DOM-Element ist oder nicht. Der HostListener setzt dann die CSS-Eigenschaft font-weight auf den fontWeight-Wert.
+- [ ] Sie richten die Direktive ein, um das DOM-Element zu überprüfen, auf dem sie sich befindet. Wenn es Event-Bindings für Maus-Enter und -Leave hinzugefügt hat, wird dieser Code verwendet. Andernfalls passiert nichts.
+- [ ] Dies ist eine falsche Verwendung von HostListener und HostBinding. Die HostListener- und HostBinding-Dekoratoren machen nichts bei Direktiven; sie funktionieren nur, wenn sie bei Komponenten verwendet werden.
+- [ ] Wenn das DOM-Element, auf dem diese Direktive platziert ist, die CSS-Eigenschaft font-weight gesetzt hat, werden die mouseenter- und mouseleave-Events ausgelöst.
+
+[DigitalOcean](https://www.digitalocean.com/community/tutorials/angular-hostbinding-hostlistener)
+
+#### F22. Welche Angular-Template-Syntax können Sie auf diesem Template-getriebenen Formularfeld verwenden, um auf den Feldwert zuzugreifen und die Validierung innerhalb des Template-Markups zu überprüfen?
+
+```html
+<input type="text" ngModel name="firstName" required minlength="4" />
+<span *ngIf="">Ungültige Felddaten</span>
+```
+
+- [x] Sie können eine Template-Referenzvariable und die exportAs-Funktion verwenden, die die ngModel-Direktive hat.
+- [ ] Sie können die ngModel-Direktive in Kombination mit dem Eingabefeldnamen verwenden.
+- [ ] Sie können eine Template-Referenzvariable für das HTML-Eingabeelement verwenden und dann die valid-Eigenschaft davon überprüfen.
+- [ ] Es ist nicht möglich, Zugriff auf den Feldwert mit Template-getriebenen Formularen zu erhalten. Sie müssen dafür reaktive Formulare verwenden.
+
+1. [Angular.io - Validierungsfehlermeldungen anzeigen und verbergen](https://angular.io/guide/forms#show-and-hide-validation-error-messages)
+2. [Medium](https://medium.com/@agoiabeladeyemi/template-driven-forms-in-angular-4a3a5ad960de)
+
+#### F23. Welcher Werttyp wird in der headerText-Template-Referenzvariablen in diesem Markup gespeichert?
+
+```html
+<h1 #headerText>Benutzerliste</h1>
+```
+
+- [x] Eine Angular ElementRef, ein Wrapper um ein natives Element
+- [ ] Der innere Text des `<h1>`-Elements
+- [ ] Eine Header-Komponentenklasse
+- [ ] Der native DOM-Elementtyp HTMLHeadingElement
+
+[Pluralsight - Template-Referenzvariable](https://www.pluralsight.com/guides/how-to-use-template-reference-variables-in-angular)
+
+#### F24. Was ist der Unterschied, falls vorhanden, der resultierenden Code-Logik basierend auf diesen beiden Provider-Konfigurationen?
+
+```ts
+[{ provide: FormattedLogger, useClass: Logger }][{ provide: FormattedLogger, useExisting: Logger }];
+```
+
+- [ ] Sie sind gleich. Beide werden zu einer neuen Instanz von Logger führen, die an das FormattedLogger-Token gebunden ist.
+- [x] Die useClass-Syntax weist den Injector an, eine neue Instanz von Logger zu erstellen und diese Instanz an das FormattedLogger-Token zu binden. Die useExisting-Syntax bezieht sich auf eine bereits existierende Objektinstanz, die als Logger deklariert ist.
+- [ ] Beide sind falsch. Ein starker Typ kann nicht für useClass oder useExisting verwendet werden.
+- [ ] Sie sind gleich. Beide werden dazu führen, dass das FormattedLogger-Token ein Alias für die Instanz von Logger ist.
+
+1. [Angular.io - Dependency Providers](https://angular.io/guide/dependency-injection-providers#defining-providers)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-providers/)
+
+#### F25. Was ist der Zweck der data-Eigenschaft (im folgenden Beispiel zu sehen) in einer Route-Konfiguration?
+
+```ts
+   {
+       path: 'customers',
+       component: CustomerListComponent,
+       data: { accountSection: true }
+   }
+```
+
+- [ ] Ein Key/Value-Mapping zum Setzen von @Input-Werten auf der gerouteten Komponenteninstanz
+- [x] Eine Möglichkeit, statische, schreibgeschützte Daten einzuschließen, die mit der Route verknüpft sind und die von der ActivatedRoute abgerufen werden können
+- [ ] Eine Eigenschaft auf der Route, die verwendet werden kann, um dynamische Daten für die Route zu laden
+- [ ] Ein Objekt, das automatisch in den Konstruktor der gerouteten Komponente injiziert wird.
+
+1. [TektutorialsHub](https://www.tektutorialshub.com/angular/angular-pass-data-to-route/#:~:text=Angular%20allows%20us%20to%20pass,of%20the%20history%20state%20object)
+2. [StackOverflow](https://stackoverflow.com/a/36835156)
+
+#### F26. Wie ändert die eingebaute strukturelle `ngIf`-Direktive das gerenderte DOM basierend auf dieser Template-Syntax?
+
+```ts
+@Component({
+  selector: 'app-product',
+  template: '<div *ngIf="product">{{ product.name }}</div>',
+})
+export class ProductComponent {
+  @Input() product;
+}
+```
+
+- [ ] Das `<div>` fungiert als Platzhalter. Wenn das product-Klassenfeld "truthy" ist, wird das `<div>` durch nur den `product.name`-Wert ersetzt; wenn nicht, wird nichts gerendert.
+- [ ] Das `<div>` wird immer gerendert, und wenn das product-Feld "truthy" ist, enthält das `<div>`-Element den `product.name`-Wert; andernfalls rendert es das `<div>`-Element ohne Wert darin.
+- [ ] Es erzeugt einen Fehler, da ngIf keine eingebaute strukturelle Direktive ist.
+- [x] Wenn das product-Klassenfeld "truthy" ist, dann enthält das gerenderte DOM das `<div>` mit dem Wert des `product.name`-Felds. Wenn es nicht "truthy" ist, enthält das gerenderte DOM nicht das `<div>`-Element.
+
+[Referenz (angular.io)](https://angular.io/api/common/NgIf)
+
+#### F27. Was bewirkt dieser Code?
+
+```ts
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic().bootstrapModule(AppModule);
+```
+
+- [ ] Es führt einen Unit-Test für ein NgModule aus.
+- [ ] Es bietet eine Möglichkeit, die Dokumentstruktur einer Angular-Anwendung zu codieren. Das @NgModule ist eine Form von Inline-Code-Kommentierung, die vom TypeScript-Compiler ignoriert wird, aber mit spezieller Formatierung in Code-Editor-Anwendungen angezeigt wird.
+- [ ] Es deklariert ein Angular-Modul namens AppModule und macht es für Lazy Loading in der gesamten Anwendung verfügbar.
+- [x] Es deklariert ein Angular-Modul namens AppModule, das eine Bootstrap-Komponente namens AppComponent enthält. Dann registriert es dieses Modul bei Angular, damit die App starten kann.
+
+[Angular.io - Das grundlegende NgModule](https://angular.io/guide/ngmodules#the-basic-ngmodule)
+
+#### F28. Welche Wahl beschreibt am besten, was die _resolve_-Eigenschaft in dieser Route-Konfiguration macht?
+
+```ts
+{
+   path: ':id',
+   component: UserComponent,
+   resolve: {
+     user: UserResolverService
+   }
+}
+```
+
+- [x] Vor dem Laden der _UserComponent_ wird der Router das _Observable_ abonnieren, das von einer _resolve_-Methode im _UserResolverService_ zurückgegeben wird. Diese Technik kann verwendet werden, um vorgeladene Daten für eine _Route_ zu erhalten.
+- [ ] Nachdem die _Route_ aufgelöst wurde und die Komponente geladen und gerendert ist, wird der _UserResolverService_ eine Methode namens _user_ ausführen, die alle offenen Datenverbindungen bereinigt.
+- [ ] Es gibt einen Fehler. Der korrekte Eigenschaftsname ist _onResolve_.
+- [ ] Die _UserComponent_ wird einen Parameter in ihrem Konstruktor für _user_ haben, und der _Router_ wird das Injizieren eines Werts dafür von einem Aufruf einer _user_-Methode im _UserResolverService_ handhaben.
+
+[angular.io](https://angular.io/api/router/Resolve)
+
+#### F29. Was ist der Zweck des ContentChildren-Dekorators in dieser Komponentenklasse?
+
+```ts
+@Component({
+ . . .
+ template: '<ng-content></ng-content>'
+})
+export class TabsListComponent {
+ @ContentChildren(TabComponent) tabs;
+}
+```
+
+- [ ] Wenn _TabsComponent_-Elemente zum _TabsListComponent_-Template hinzugefügt werden, werden sie zur Laufzeit in das `<ng-content>`-Element eingefügt.
+- [ ] Es erstellt _TabComponent_-Komponenten im _TabsListComponent_-Template, wenn eine _TabsListComponent_ instanziiert wird.
+- [x] Es bietet Zugriff von innerhalb der Komponentenklasse auf alle _TabComponent_-Komponenten, die in das `<ng-content>` für diese Komponente projiziert wurden.
+- [ ] Es beschränkt die erlaubten Elemente, die in ein _TabsListComponent_-Element eingefügt werden können, um nur _TabComponent_-Elemente zuzulassen.
+
+[betterprogramming.pub](https://betterprogramming.pub/understanding-contentchildren-with-an-example-e76ce78968db)
+
+#### F30. Damit Angular Komponenten in einer Anwendung verarbeiten kann, wo müssen die Komponententypen registriert werden?
+
+- [ ] Innerhalb eines script-Tags in der index.html-Datei
+- [ ] In einem NgModule-Dekorator-Metadaten-Tag namens _components_
+- [ ] Keine Registrierung ist erforderlich, fügen Sie einfach die Komponentendateien in ein App-Verzeichnis ein.
+- [x] In einer NgModule-Dekorator-Metadaten-Eigenschaft namens _declarations_
+
+[angular.io](https://angular.io/guide/ngmodule-api#ngmodule-metadata)
+
+#### F31. Was ist der Zweck des `fixture.detectChanges()`-Aufrufs in diesem Unit-Test?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+
+fixture.detectChanges();
+
+expect(fixture.nativeElement.querySelector('h1').textContent).toContain(
+  fixture.componentInstance.title,
+);
+```
+
+- [ ] Es verfolgt alle potenziellen UI-Änderungen und lässt den Unit-Test fehlschlagen, wenn welche vorgenommen werden.
+- [ ] Es wird verwendet, um die Stabilität des Komponenten-Templates über mehrere Unit-Tests in der gesamten Test-Suite hinweg zu gewährleisten.
+- [x] Es zwingt Angular, Change Detection durchzuführen, was die _UserCardComponent_ rendert, bevor Sie ihr Template validieren können.
+- [ ] Es wird verwendet, um Change-Detection-Events während Unit-Test-Läufen in der Konsole zu protokollieren.
+
+[angular.io](https://angular.io/api/core/testing/ComponentFixture#detectChanges)
+
+#### F32. Wie wird das URL-Segment aussehen, basierend auf dem folgenden Aufruf der `Router.navigate`-Methode, wenn goToUser mit dem Wert 15 übergeben wird?
+
+```ts
+export class ToolsComponent {
+  constructor(private router: Router) {}
+  goToUser(id: number) {
+    this.router.navigate(['user', id]);
+  }
+}
+```
+
+- [x] /user/15
+- [ ] /user?id=15
+- [ ] /user:15
+- [ ] /user;id=15
+
+[angular.io](https://angular.io/api/router/Router#navigate)
+
+#### F33. Wenn ein Service für root bereitgestellt wird und auch zur Provider-Konfiguration für ein Lazy-Loaded-Modul hinzugefügt wird, welche Instanz dieses Services stellt der Injector Konstruktoren im Lazy-Loaded-Modul bereit?
+
+- [x] Eine neue Instanz dieses Services wird erstellt, wenn das Modul lazy geladen wird.
+- [ ] Das Bereitstellen eines Services desselben Typs auf der Ebene eines Lazy-Loaded-Moduls ist nicht erlaubt.
+- [ ] Wenn eine Instanz des Services noch nicht auf der Root-Ebene erstellt wurde, wird eine dort erstellt und dann verwendet.
+- [ ] Eine einzelne Instanz dieses Services wird immer auf der Root-Ebene instanziiert und ist die einzige, die jemals verwendet wird, einschließlich innerhalb von Lazy-Modulen.
+
+#### F34. Was macht der HostBinding-Dekorator in dieser Direktive?
+
+```ts
+@Directive({
+  selector: ' [appHighlight] ',
+})
+export class HighlightDirective {
+  @HostBinding('class.highlighted') highlight = true;
+}
+```
+
+- [x] Er fügt die CSS-Klasse namens highlighted zu jedem DOM-Element hinzu, das die appHighlight-Direktive darauf hat.
+- [ ] HostBinding macht nichts bei Direktiven, nur bei Komponenten.
+- [ ] Er spezifiziert, dass wenn das Host-Element die highlighted-Klasse zu seinem class-Attribut hinzugefügt bekommt, dann das Direktiven-Klassenfeld highlight auf true gesetzt wird; und wenn es nicht auf dem Host hinzugefügt wird, wird es auf false gesetzt.
+- [ ] Er erstellt einen Inline-Stil auf dem Host-Element mit einer CSS-Eigenschaft namens highlight, die auf true gesetzt ist.
+
+[StackOverflow](https://stackoverflow.com/a/46207423)
+
+#### F35. In reaktiven Formularen, welcher Angular-Formularklassentyp wird auf dem nativen DOM-`<form>`-Element verwendet, um es zu verdrahten?
+
+- [ ] `FormArray`
+- [ ] `FormControl`
+- [x] `FormGroup`
+- [ ] `alle diese Antworten`
+
+#### F36. Angenommen, das username-FormControl wurde mit einem minLength-Validator konfiguriert, wie können Sie eine Fehleranzeige im folgenden reaktiven Formular-Markup für das username-Feld einrichten?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  ...
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <span *ngIf="username.minLength.invalid"> Benutzername-Länge ist nicht gültig </span>
+  ```
+
+- [ ] B
+
+  ```html
+  <input type="text" formControlName="username" [showMinLength]="true" />
+  ```
+
+- [ ] C
+
+  ```html
+  <span *ngIf="form.get('username').getError('minLength') as minLengthError">
+    Benutzername muss mindestens {{ minLengthError.requiredLength }} Zeichen lang sein.
+  </span>
+  ```
+
+- [x] D
+
+  ```html
+  <input type="text" formControlName="username" #userName="ngModel" />
+  <span *ngIf="userName.errors.minlength">
+    Benutzername muss mindestens {{ userName.errors.minlength.requiredLength }} Zeichen lang sein.
+  </span>
+  ```
+
+[Codecraft](https://codecraft.tv/courses/angular/forms/template-driven/)
+
+#### F37. Wie handhabt der emulierte View-Encapsulation-Modus CSS für eine Komponente?
+
+- [ ] Er rendert das CSS genau so, wie Sie es geschrieben haben, ohne Änderungen.
+- [ ] Er macht Gebrauch von Shadow-DOM-Markup und CSS.
+- [x] Er erstellt eindeutige Attribute für DOM-Elemente und beschränkt die CSS-Selektoren, die Sie schreiben, auf diese Attribut-IDs.
+- [ ] Er rendert alle CSS-Regeln, die Sie schreiben, als Inline-CSS auf allen DOM-Elementen, die Sie im Template verwenden.
+
+[Angular.io](https://angular.io/guide/view-encapsulation#inspecting-generated-css)
+
+#### F38. Mit dem folgenden TestBed-Setup, was kann verwendet werden, um auf das gerenderte DOM für die UserCardComponent zuzugreifen?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+```
+
+- [ ] `fixture.componentTemplate`
+- [ ] `fixture.getComponentHtml()`
+- [x] `fixture.nativeElement`
+- [ ] `fixture.componentInstance.template`
+
+1. [StackOverflow](https://stackoverflow.com/a/56504773)
+2. [Angular.io](https://angular.io/guide/testing-components-basics#nativeelement)
+
+#### F39. Gegeben diese beiden Komponenten, was wird basierend auf der Markup-Verwendung in das DOM gerendert?
+
+```ts
+@Component({
+ selector: 'app-card',
+ template: '<h1>Datenkarte</h1><ng-content></ng-content>'
+})
+export class CardComponent { }
+
+@Component({
+ selector: 'app-bio',
+ template: '<ng-content></ng-content>.
+})
+export class BioComponent { }
+
+// Markup-Verwendung:
+<app-card><app-bio>Seit vier Jahren dabei.</app-bio></app-card>
+```
+
+- [x] A
+
+  ```html
+  <app-card>
+    <h1>Datenkarte</h1>
+    <app-bio> Seit vier Jahren dabei. </app-bio>
+  </app-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Datenkarte</h1>
+  <app-bio>Seit vier Jahren dabei.</app-bio>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-card>
+    <h1>Datenkarte</h1>
+    <ng-content></ng-content>
+    <app-bio> Seit vier Jahren dabei. <ng-content></ng-content> </app-bio>
+  </app-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <app-card>
+    <h1>Datenkarte</h1>
+  </app-card>
+  ```
+
+#### F40. Gegeben die app-title-card-Komponente im folgenden Code, welches DOM wird die app-user-card-Komponente rendern?
+
+```ts
+@Component({
+   selector: 'app-user-card',
+   template: '<app-title-card></app-title-card><p>Jenny Smith</p>'
+})
+
+@Component({
+   selector: 'app-title-card',
+   template: '<h1>Benutzerdaten</h1>'
+})
+
+// Verwendung der User-Card-Komponente im HTML der übergeordneten Komponente
+<app-user-card></app-user-card>
+```
+
+- [x] A
+
+  ```html
+  <app-user-card>
+    <app-title-card>
+      <h1>Benutzerdaten</h1>
+    </app-title-card>
+    <p>Jenny Smith</p>
+  </app-user-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Benutzerdaten</h1>
+  <p>Jenny Smith</p>
+  <p></p>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-user-card>
+    <app-title-card></app-title-card>
+  </app-user-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <div app-user-card>
+    <h1 app-title-card>Benutzerdaten</h1>
+    <p>Jenny Smith</p>
+  </div>
+  ```
+
+#### F41. Wählen Sie den passenden Code für die benutzerdefinierte Provider-Registrierung aus, nach der der @Inject()-Dekorator sucht:
+
+```ts
+constructor(@Inject('Logger') private logger) { }
+```
+
+- [ ] A
+
+  ```ts
+  providers: [Logger];
+  ```
+
+- [x] B
+
+  ```ts
+  providers: [{ provide: 'Logger', useClass: Logger }];
+  ```
+
+- [ ] C
+
+  ```ts
+  @Injectable({
+      providedln: 'root'
+  })
+  ```
+
+- [ ] D
+
+  ```ts
+  providers: [{ provide: 'Logger' }];
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/37315355)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-injector-injectable-inject/)
+3. [Angular.io - Dependency Injection In Action](https://angular.io/guide/dependency-injection-in-action#supply-a-custom-provider-with-inject)
+
+#### F42. Welche Wahl beschreibt am besten die folgende Verwendung der HttpClient.get-Methode in der getsettings-Klassenmethode?
+
+```ts
+export class SettingsService {
+    constructor(private httpClient: HttpClient) { }
+    ...
+
+getSettings()
+{
+    return this.httpClient.get<Settings>(this.settingsUrl)
+        .pipe(
+            retry(3)
+        );
+}}
+```
+
+- [ ] Die RxJs-pipe-Methode ist ein Alias für die subscribe-Methode, sodass ein Aufruf von `getSettings` die get-Abfrage ausführt. Der retry-Operator wird verwendet, um dem pipe-Aufruf mitzuteilen, die get-Abfrage dreimal zu wiederholen.
+- [ ] Es wird zur Laufzeit einen Fehler erzeugen, da die pipe-Methode nicht vom `Httpclient.get`-Aufruf verfügbar ist.
+- [ ] Jeder einzelne Aufruf der getSettings-Methode wird dazu führen, dass der Httpclient insgesamt drei get-Anfragen an die settingsUrl macht, was nicht ideal ist, da es immer zwei zusätzliche Aufrufe geben wird, die nicht benötigt werden. Der retry-Operator sollte nicht auf diese Weise verwendet werden.
+- [x] Wenn das Ergebnis der getSettings-Methode abonniert wird, wird der HTTP GET-Aufruf gemacht; wenn er fehlschlägt, wird er bis zu dreimal wiederholt, bevor er aufgibt und einen Fehler zurückgibt.
+
+1. [learnrxjs.io](https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retry)
+2. [dev.to](https://dev.to/gparlakov/how-does-rxjs-retry-work-412p)
+
+#### F43. Wenn ein Service eine gewisse Einrichtung benötigt, um seinen Standardzustand durch eine Methode zu initialisieren, wie können Sie sicherstellen, dass diese Methode aufgerufen wird, bevor der Service irgendwo injiziert wird?
+
+- [ ] Legen Sie die Logik dieser Service-Methode stattdessen in den Service-Konstruktor.
+- [x] Verwenden Sie einen Factory-Provider auf der Root-AppModule-Ebene, der vom Service abhängt, um diese Service-Methode aufzurufen.
+- [ ] Es ist nicht möglich, dies beim Anwendungsstart zu tun; Sie können es nur auf Komponentenebene tun.
+- [ ] Instanziieren Sie eine Instanz des Services auf globaler Ebene (Window-Scope) und rufen Sie dann diese Methode auf.
+
+1. [Angular.io](https://angular.io/guide/dependency-injection-providers)
+2. [Stackoverflow](https://stackoverflow.com/questions/39803876/how-to-use-factory-provider)
+
+#### F44. Was beschreibt diese Verwendung des TestBed am besten?
+
+```ts
+const spy = jasmine.createSpyObj('DataService', ['getUsersFromApi']);
+TestBed.configureTestingModule({
+  providers: [UserService, { provide: DataService, useValue: spy }],
+});
+const userService = TestBed.get(UserService);
+```
+
+- [ ] Das TestBed ist erforderlich, wenn Sie ein Spy-Objekt in einem Unit-Test für einen Angular-Provider verwenden möchten.
+- [ ] Das TestBed wird verwendet, um die Ansicht einer Komponente zu testen.
+- [x] Das TestBed erstellt ein NgModule mit zwei Providern und behandelt alle Dependency Injection. Wenn eine Angular-Klasse den DataService in ihrem Konstruktor anfordert, wird das TestBed spy in diesem Konstruktor injizieren.
+- [ ] Das TestBed konfiguriert den Test-Runner, um ihm mitzuteilen, dass er nur Tests für die beiden Provider ausführt, die in seinem providers-Array aufgelistet sind.
+
+`Alle anderen Tests werden ignoriert, einschließlich Tests, die Ergebnisse gegen einen dieser Provider und einen nicht definierten Provider bestätigen.`
+`Obwohl es funktioniert, wenn mehrere Provider in dieser Konfiguration in einem einzigen Test bestätigt werden.`
+
+#### F45. Was ist der Hauptunterschied zwischen einer Komponente und einer Direktive?
+
+- [ ] Eine Komponente verwendet eine selector-Metadaten-Eigenschaft und eine Direktive nicht.
+- [ ] Eine Direktive kann verwendet werden, um benutzerdefinierte Events zum DOM hinzuzufügen, und eine Komponente kann das nicht.
+- [x] Eine Komponente hat ein Template und eine Direktive nicht.
+- [ ] Eine Direktive kann nur native DOM-Elemente ansprechen.
+
+[StackOverflow](https://stackoverflow.com/a/34616190)
+
+#### F46. Was könnten Sie zu dieser Direktivenklasse hinzufügen, um die Truncate-Länge während der Direktiven-Verwendung im Markup festzulegen?
+
+```ts
+@Directive({
+    selector: '[appTruncate]'
+})
+export class TruncateDirective {
+    . . .
+}
+
+// Beispiel der gewünschten Verwendung:
+<p [appTruncate]="10">Sehr langer Text hier</p>
+```
+
+- [x] `@Input() appTruncate: number;`
+- [ ] `@Output() appTruncate;`
+- [ ] `constructor(maxLength: number) { }`
+- [ ] `Nichts. Der Direktiven-Selektor kann nicht verwendet werden, um Werte an die Direktive zu übergeben.`
+
+1. [Angular.io](https://angular.io/guide/attribute-directives#passing-values-into-an-attribute-directive)
+2. [StackOverflow](https://stackoverflow.com/a/46303049)
+
+#### F47. Wie können Sie Query-Parameter an diese `HttpClient.get`-Anfrage übergeben?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  getOrdersByYear(year: number): Observable<Order[]> {
+    return this.httpClient.get<Order[]>(this.ordersUrl);
+  }
+}
+```
+
+- [ ] A `return this.httpClient.get<Order[]>(this.ordersUrl, {'year': year})`
+- [ ] B `return this.httpClient.get<Order[]>(this.ordersUrl, year)`
+- [x] C
+
+  ```ts
+  const options = { params: new HttpParams().set('year', year) };
+  return this.httpClient.get<Order[]>(this.ordersUrl, options);
+  ```
+
+- [ ] D
+
+  ```ts
+  getOrdersByYear(year: number): Observable<Order[]> {
+      return this.httpClient.addParam('year', year).get<Order[]>(this.ordersUrl, year);
+  }
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/34475594)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-pass-url-parameters-query-strings/#httpparams)
+
+#### F48. Angenommen, der `DataService` wurde in den Providern für die Anwendung registriert, welche Antwort beschreibt am besten, was basierend auf dem Konstruktor dieser Komponente passiert?
+
+```ts
+@Component({
+    ...
+})
+export class OrderHistoryComponent {
+    constructor(private dataService: DataService) {}
+    ...
+}
+```
+
+- [ ] Es deklariert, dass die `OrderHistoryComponent` ihre eigene Version eines `DataService` haben wird und dass sie niemals existierende Instanzen verwenden sollte. Der `DataService` müsste innerhalb der Klasse als privates Feld instanziiert werden, damit dieser Code vollständig und funktionsfähig ist.
+- [x] Wenn Angular eine neue Instanz der `OrderHistoryComponent` erstellt, wird der Injector eine Instanz einer `DataService`-Klasse dem ersten Argument des Komponenten-Konstruktors bereitstellen. Der dataService-Parameter des Konstruktors wird verwendet, um ein privates Instanzfeld mit demselben Namen auf der Instanz zu setzen.
+- [ ] Es bietet eine Möglichkeit, nur Komponententests durchzuführen; der Konstruktor hat keine Verwendung im tatsächlichen Betrieb der Angular-Anwendung.
+- [ ] Es ermöglicht es dem benutzerdefinierten Element, auf das die Komponente abzielt, eine benutzerdefinierte Eigenschaft namens `dataService` zu haben, die verwendet werden kann, um eine existierende `DataService`-Instanz zu binden.
+
+1. [StackOverflow](https://stackoverflow.com/a/49755822)
+2. [Angular.io - Dependency Injection](https://angular.io/guide/dependency-injection)
+
+#### F49. Vervollständigen Sie dieses Markup mit der `ngIf`-Direktive, um einen else-Fall zu implementieren, der den Text "Benutzer ist nicht aktiv" anzeigt:
+
+```html
+<div *ngIf="userIsActive; else inactive">Derzeit aktiv!</div>
+```
+
+- [ ] A
+
+  ```html
+  <div #inactive>Benutzer ist nicht aktiv.</div>
+  ```
+
+- [ ] B
+
+  ```html
+  <div *ngIf="inactive">Benutzer ist nicht aktiv.</div>
+  ```
+
+- [ ] C
+
+  ```html
+  <ng-template #else="inactive">
+    <div>Benutzer ist nicht aktiv.</div>
+  </ng-template>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-template #inactive>
+    <div>Benutzer ist nicht aktiv.</div>
+  </ng-template>
+  ```
+
+[Angular.io](https://angular.io/api/common/NgIf)
+
+#### F50. Was ist die korrekte Syntax für eine Route-Definition zum Lazy Loading eines Feature-Moduls?
+
+- [ ] A
+
+  ```ts
+  {
+    path: 'users',
+    lazy: './users/users.module#UsersModule'
+  }
+  ```
+
+- [x] B
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: () => import('./users/users.module').then(m => m.UserModule)
+  }
+  ```
+
+- [ ] C
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: './users/users.module#UsersModule'
+  }
+  ```
+
+- [ ] D
+
+  ```ts
+  {
+    path: 'users',
+    module: UsersModule
+  }
+  ```
+
+[Angular.io - Lazy Loading Modules](https://angular.io/guide/lazy-loading-ngmodules)
+
+#### F51. Beschreiben Sie, wie die Validierung in diesem reaktiven Formular-Beispiel eingerichtet und konfiguriert ist:
+
+```ts
+export class UserFormControl implements OnInit {
+    ...
+    ngOnInit() {
+        this.form = this.formBuilder.group({
+            username: this.formBuilder.control('',
+                [Validators.required, Validators.minLength(5), this.unique]),
+        )};
+    }
+    unique(control: FormControl) {
+        return control.value !== 'admin' ? null: {notUnique: true};
+    }
+}
+```
+
+- [ ] Das `FormControl` für `username` wird konfiguriert, um drei Validatoren von den Validatoren auszuschließen, die es verwenden darf.
+- [ ] Das `FormControl` für `username` wird konfiguriert, um drei mögliche Validatoren zuzulassen: `required, maxLength` und einen benutzerdefinierten namens `unique`. Um diese `Validatoren` zu aktivieren, müsste eine Validator-Direktive auf die Formularfelder im Markup gesetzt werden.
+- [ ] Validierung kann auf diese Weise in reaktiven Formularen nicht eingerichtet werden.
+- [x] Das `FormControl` für `username` wird mit drei Validatoren konfiguriert: den `required`- und `minLength`-Validatoren, die von Angular kommen, und einer benutzerdefinierten Validator-Funktion namens `unique`, die prüft, ob der Wert nicht gleich dem String `admin` ist.
+
+1. [Angular.io - Formularvalidierung](https://angular.io/guide/form-validation)
+2. [Angular University Blog](https://blog.angular-university.io/angular-custom-validators/)
+
+#### F52. Was macht der Injectable-Dekorator auf dieser Service-Klasse?
+
+```ts
+@Injectable({
+    providedIn: 'root'
+)}
+export class DataService { }
+```
+
+- [ ] Er registriert einen Provider für den Service, der nur auf der Root-Modul-Ebene verfügbar ist, nicht für untergeordnete Module.
+- [x] Er registriert einen Provider für den Service im Root-Anwendungs-Injector, wodurch eine einzelne Instanz davon in der gesamten Anwendung verfügbar gemacht wird.
+- [ ] Er macht es so, dass der Service nur in der Bootstrap-Komponente für die Anwendung injiziert werden kann.
+- [ ] Er richtet eine Kompilierzeit-Regel ein, die es Ihnen erlaubt, den Service-Typ nur in die providers-Metadaten-Eigenschaft des Root-NgModuls zu setzen.
+
+[Angular.io](https://angular.io/guide/providers#providing-a-service)
+
+#### F53. Beschreiben Sie die Verwendung dieses Codes
+
+```ts
+export interface AppSettings {
+  title: string;
+  version: number;
+}
+export const APP_SETTINGS = new InjectionToken<AppSettings>('app.settings');
+```
+
+- [ ] Das InjectionToken fügt eine Instanz der AppSettings zum Root-Provider über den InjectionToken-Konstruktor-Aufruf hinzu und macht es automatisch für alle NgModules, Services und Komponenten in der gesamten Angular-Anwendung verfügbar, ohne dass es irgendwo injiziert werden muss.
+- [x] Das InjectionToken wird verwendet, um ein Provider-Token für eine Nicht-Klassen-Abhängigkeit zu erstellen. Ein Objekt-Literal kann als Wert für den APP_SETTINGS-Dependency-Provider-Typ bereitgestellt werden, der dann in Komponenten, Services usw. injiziert werden kann.
+- [ ] Das InjectionToken wird verwendet, um einen dynamischen Dekorator für die AppSettings zu erstellen, der auf Konstruktor-Parametern über einen @AppSettings-Dekorator verwendet werden kann.
+- [ ] Dieser Code hat einen Fehler, da Sie kein TypeScript-Interface für den generischen Typ auf dem InjectionToken verwenden können
+
+#### F54. Für das folgende Template-getriebene Formular-Beispiel, welches Argument kann an die submit-Methode im click-Event übergeben werden, um die Daten für das Formular zu übermitteln?
+
+```html
+<form #form="ngForm">
+  <input type="text" ngModel="firstName" /> <input type="text" ngModel="lastName" />
+  <button (click)="submit()">Speichern</button>
+</form>
+```
+
+- [x] submit(form.value)
+- [ ] submit($event)
+- [ ] submit(ngForm.value)
+- [ ] submit(FirstName, lastName)
+
+#### F55. Was ist der Zweck der `prelodingStrategy`-Eigenschaftskonfiguration in diesem Router-Code?
+
+```ts
+RouterModule.forRoot(
+  ...{
+    preloadingStrategy: PreloadAllModules,
+  },
+);
+```
+
+- [ ] Es aktiviert die Option, einzelne Routen für das Vorladen zu markieren.
+- [ ] Es lädt alle Abhängigkeiten für Routen vor und erstellt Instanzen von Services, wenn die App zum ersten Mal startet
+- [ ] Es stellt sicher, dass alle Module in eine einzelne App-Modul-Bundle-Datei gebaut werden.
+- [x] Es konfiguriert den Router, um sofort alle Routen zu laden, die eine loadChildren-Eigenschaft haben (Routen, die normalerweise bei Bedarf geladen werden)
+
+Referenzen:
+
+- [Angular Router, PreloadAllModules](https://angular.io/api/router/PreloadAllModules)
+- [Route-Vorladen in Angular](https://web.dev/route-preloading-in-angular/)
+- [Vorladen-Strategie](https://www.tektutorialshub.com/angular/angular-preloading-strategy/)
+- [Benutzerdefinierte Vorladen-Strategie](https://www.concretepage.com/angular-2/angular-custom-preloading-strategy#Preloading)
+- [Vorladen-Strategie, Ladezeit sparen](https://medium.com/geekculture/preloading-strategy-in-angularsave-loading-time-ca791074fe28)
+
+#### F56. Was ist eine alternative Möglichkeit, dieses Markup zu schreiben, um den Wert des Klassenfelds `userName` an die title-Eigenschaft des h1-Elements zu binden?
+
+```html
+<h1 [title]="userName">Aktueller Benutzer ist {{ userName }}</h1>
+```
+
+- [ ] `title="userName"`
+- [x] `title="{{ userName }}"`
+- [ ] `title="{{ 'userName' }}"`
+- [ ] Der einzige Weg, dies zu tun, ist die Verwendung der eckigen Klammern.
+
+#### F57. Was macht die `async`-Pipe in diesem Beispiel?
+
+```ts
+@Component({
+  selector: 'app-users',
+  template: '<div *ngFor="let user of users | async">{{ user.name }}</div>',
+})
+export class UsersComponent implements OnInit {
+  users;
+  constructor(private httpClient: HttpClient) {}
+  ngOnInit(): void {
+    this.users = this.httpClient.get<{ name: string }>('users');
+  }
+}
+```
+
+- [ ] Sie macht nichts, da die async-Pipe nicht in einer `ngFor`-Anweisung verwendet werden kann.
+- [ ] Sie konfiguriert die `ngFor`-Iteration, um mehrere Listen von Benutzern gleichzeitig zu unterstützen.
+- [x] Sie abonniert das Observable, das von der `HttpClient.get`-Methode zurückgegeben wird, und entpackt den zurückgegebenen Wert, sodass er in der `ngFor` iteriert werden kann.
+- [ ] Sie ermöglicht es, dass alle Benutzer im `users`-Feld gleichzeitig zum DOM gerendert werden.
+
+#### F58. Wie würden Sie diese Direktive im Markup basierend auf ihrem Selektor-Wert verwenden?
+
+```ts
+@Directive({  selector: '[appTruncate]'
+})
+export class TruncateDirective{  . . .
+}
+```
+
+- [ ] `html <p data-directive="appTruncate">Langer Text </p> `
+- [x] `html <p appTruncate>Langer Text</p> `
+- [ ] `html <p app-truncate>Langer Text</p> `
+- [ ] `html <app-truncate>Langer Text</app-truncate> `
+
+#### F59. Welcher Lifecycle-Hook kann auf einer Komponente verwendet werden, um alle Änderungen an @Input-Werten auf dieser Komponente zu überwachen?
+
+- [ ] ngOnInit
+- [ ] ngChanges
+- [ ] ngAfterInputChange
+- [x] ngOnChanges
+
+[Wie erkennt man, wann sich ein @Input()-Wert in Angular ändert?](https://stackoverflow.com/a/44686085/1573267)
+
+#### F60. Was wäre ein Beispiel für die Template-Syntax-Verwendung dieser benutzerdefinierten Pipe?
+
+```ts
+@Pipe({ name: 'truncate' })
+export class TruncatePipe implements PipeTransform {
+  transform(value: string, maxLength: number, showEllipsis: boolean) {
+    const newValue = maxLength ? value.substr(0, maxLength) : value;
+    return showEllipsis ? '${newValue}...' : newValue;
+  }
+}
+```
+
+- [ ] `{{ 'langer Text' | truncate:10 }}`
+- [x] `{{ 'langer Text' | truncate: 10, true }}`
+- [ ] `{{ 'langer Text' | truncate }}`
+- [ ] alle diese Antworten
+
+[Wie rufe ich eine Angular 2 Pipe mit mehreren Argumenten auf?](https://stackoverflow.com/questions/36816788/how-do-i-call-an-angular-2-pipe-with-multiple-arguments)
+
+#### F61. Welchen Angular CLI-Befehl würden Sie ausführen, um eine UsersComponent zu generieren und sie zum SharedModule hinzuzufügen (in der Datei shared.module.ts in Ihrer Anwendung)?
+
+- [ ] ng generate component --newModule=shared
+- [x] ng generate component users --module=shared
+- [ ] ng generate component users --shared
+- [ ] ng generate component --add=shared
+
+#### F62. Wie können Sie dieses Markup umschreiben, sodass der div-Container im finalen DOM-Rendering nicht benötigt wird?
+
+```html
+<div *ngIf="location">
+  <h1>{{ location.name }}</h1>
+  <p>{{ location.description }}</p>
+</div>
+```
+
+- [ ] A
+
+  ```html
+  <div *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+    {{ endNgIf }}
+  </div>
+  ```
+
+- [ ] B
+
+  ```html
+  <ng-template *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-template>
+  ```
+
+- [ ] C
+
+  ```html
+  <div *ngIf="location" [display]=" ' hidden' ">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </div>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-container *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-container>
+  ```
+
+#### F63. Wie können Sie die Template-Syntax verwenden, um ein Komponenten-Klassenfeld namens tabWidth an eine Inline-Style-CSS-Eigenschaft width auf diesem Element zu binden?
+
+<div class="tab"></div>
+
+- [ ] <code>{{ width: tabWidth }}</code>
+- [ ] [width]="tabWidth"
+- [ ] [inline.width]="tabWidth"
+- [x] [style.width.px]="tabWidth"
+
+#### F64. Welche Angular-Utilities, falls vorhanden, sind erforderlich, um einen Service ohne Konstruktor-Abhängigkeiten per Unit-Test zu testen?
+
+- [ ] Die By.css()-Hilfsmethode wird benötigt
+- [ ] Eine Text-Fixture ist erforderlich, um den Service für den Unit-Test auszuführen.
+- [ ] Keine. Ein Service kann instanziiert und eigenständig per Unit-Test getestet werden.
+- [x] Die TestBed-Klasse wird benötigt, um den Service zu instanziieren.
+
+[Angular Unit-Tests](https://angular.io/guide/testing-services) - Antworten erneut prüfen
+
+#### F65. Was ist der Unterschied zwischen den CanActivate- und den CanLoad-Route-Guards?
+
+- [ ] CanActivate wird verwendet, um den Zugriff zu überprüfen. CanLoad wird verwendet, um Daten für die Route vorzuladen.
+- [ ] CanLoad wird beim App-Start verwendet, um das Hinzufügen von Routen zur Route-Tabelle zu erlauben oder zu verweigern. CanActivate wird verwendet, um den Zugriff auf Routen zum Zeitpunkt ihrer Anforderung zu verwalten.
+- [ ] CanActivate und CanLoad machen genau dasselbe.
+- [x] CanLoad verhindert, dass ein gesamtes NgModule ausgeliefert und geladen wird. CanActivate stoppt das Routing zu einer Komponente in diesem NgModule, aber dieses Modul wird trotzdem geladen.
+
+[CanActivate vs Canload](https://stackoverflow.com/questions/42026045/difference-between-angulars-canload-and-canactivate#:~:text=canActivate%20is%20used%20to%20prevent,not%20authorized%20to%20do%20so.) CanActivate verhindert den Zugriff auf Routen, CanLoad verhindert Lazy Loading.
+
+#### F66. Wofür wird die outlet-Eigenschaft in diesem Router-Definitionsobjekt verwendet?
+
+```ts
+{  path: 'document',  component: DocumentComponent,  outlet: 'document-box'
+}
+```
+
+- [ ] Es findet alle Instanzen von `<document-box>` im DOM und fügt bei der Routen-Navigation ein DocumentComponent-Element in sie ein.
+- [ ] Es deklariert, dass die DocumentComponent zusätzlich zum Routing als Kind eines `<document-box>`-Elements verwendet werden kann.
+- [x] Es wird verwendet, um ein `<router-outlet>`-Element mit dem name-Attribut, das mit dem String-Wert übereinstimmt, als Ort für das Rendern der DocumentComponent beim Routing anzusprechen.
+- [ ] Es ist eine Stromquelle für den Router. (definitiv nicht die Antwort :P)
+
+[Angular-outlet](https://angular.io/api/router/RouterOutlet) - Antwort erneut prüfen
+
+#### F67. In dieser Template-Syntax führt die ngFor-Strukturdirektive jedes Mal, wenn die items-Eigenschaft geändert wird (hinzugefügt, entfernt usw.), ihre Logik für alle DOM-Elemente in der Schleife erneut aus. Welche Syntax kann verwendet werden, um dies performanter zu machen?
+
+```html
+<div *ngFor="let item of items">{{ item.id }} - {{ item.name }}</div>
+```
+
+- [ ] `*ngFor="let item of items; let uniqueItem"`
+- [ ] `*ngFor="let item of items.distinct()"`
+- [ ] `*ngFor="let item of items: let i = index"`
+- [x] `*ngFor="let item of items; trackBy: trackById"`
+
+[StackOverflow - Wie man `trackBy` mit `ngFor` verwendet](https://stackoverflow.com/a/58025894)
+
+#### F68. Was macht dieser Angular CLI-Befehl?
+
+```bash
+ng build --configuration=production --progress=false
+```
+
+- [ ] Er baut die Angular-Anwendung, setzt die Build-Konfiguration auf das "production"-Ziel, das in der angular.json-Datei angegeben ist, und protokolliert die Fortschrittsausgabe in der Konsole.
+- [ ] Er baut die Angular-Anwendung, setzt die Build-Konfiguration auf das "production"-Ziel, das in der angular.json-Datei angegeben ist, und überwacht Dateien auf Änderungen.
+- [ ] Er baut die Angular-Anwendung, setzt die Build-Konfiguration auf das "production"-Ziel, das in der angular.json-Datei angegeben ist, und deaktiviert das Überwachen von Dateien auf Änderungen.
+- [x] Er baut die Angular-Anwendung, setzt die Build-Konfiguration auf das "production"-Ziel, das in der angular.json-Datei angegeben ist, und verhindert die Fortschrittsausgabe in der Konsole.
+
+[Angular-Dokumentation - `ng build`](https://angular.io/cli/build#:~:text=%2D%2D-,progress,-Log%20progress%20to)
+
+#### F69. Service-Klassen können als Provider über welche Dekoratoren registriert werden?
+
+- [ ] @Injectable, @NgModule, @Component und @Directive.
+- [x] Nur @Injectable.
+- [ ] Nur @Injectable und @NgModule.
+- [ ] Nur @Service und @NgModule.
+
+#### F70. Wofür wird der Input-Dekorator in dieser Komponentenklasse verwendet?
+
+```ts
+@Component({  selector:'app-product-name',  ...
+})
+export class ProductNameComponent {  @Input() productName: string
+}
+```
+
+- [ ] Er wird einfach verwendet, um einen Kommentar vor ein Klassenfeld zur Dokumentation zu setzen.
+- [x] Er bietet eine Möglichkeit, Werte an das productName-Feld zu binden, indem der Komponenten-Selektor verwendet wird.
+- [ ] Er generiert automatisch ein `html
+<input type='text' id='productName'>` DOM-Element im Komponenten-Template.
+- [ ] Er bietet eine Möglichkeit, Werte an das productName-Instanzfeld zu binden, genau wie native DOM-Element-Property-Bindings.
+      [Angular-Dokumentation - `Input()`](https://angular.io/guide/inputs-outputs)
+
+#### F71. Welcher Route-Guard kann verwendet werden, um die Navigation zu einer Route zu vermitteln?
+
+- [x] alle diese Antworten.
+- [ ] CanDeactivate.
+- [ ] CanLoad
+- [ ] CanActivate.
+      [Angular-Dokumentation - `Input()`](https://angular.io/guide/inputs-outputs)
+
+#### F72. Wie können Sie den Injector konfigurieren, um ein vorhandenes Objekt für ein Token zu verwenden, anstatt eine Klasseninstanz zu instanziieren?
+
+- [x] Verwenden Sie die `useValue`-Provider-Konfiguration und setzen Sie diese gleich einem vorhandenen Objekt oder einem Objekt-Literal.
+- [ ] Es ist nicht möglich. Provider können nur mit Klassentypen konfiguriert werden.
+- [ ] Fügen Sie einfach die Objektinstanz oder das Literal zum Provider-Array hinzu.
+- [ ] Nutzen Sie die `asValue`-Provider-Konfigurationseigenschaft und setzen Sie sie auf true.
+
+[Konfiguration von Dependency-Providern](https://angular.io/guide/dependency-injection-providers)
+
+#### F73. Basierend auf dieser Route-Definition, was kann in den UserDetailComponent-Konstruktor injiziert werden, um den id-Route-Parameter zu erhalten?
+
+```ts
+{path: 'user/:id', component: UserDetailComponent }
+```
+
+- [x] ActivatedRoute
+- [ ] CurrentRoute
+- [ ] UrlPath
+- [ ] @Inject('id')
+
+[Häufige Routing-Aufgaben](https://angular.io/guide/router#observable-parammap-and-component-reuse)
+
+#### F74. Mit dem folgenden reaktiven Formular-Markup, was würden Sie hinzufügen, um einen Aufruf an eine onSubmit-Klassenmethode zu verdrahten?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  <button type="submit" [disabled]="form. invalid">Absenden</button>
+</form>
+```
+
+- [ ] keine dieser Antworten
+- [ ] Fügen Sie (click)="onSubmit()" zum `<button>`-Element hinzu.
+- [x] Fügen Sie (ngSubmit )="onSubmit ()" zum `<form>`-Element hinzu.
+- [ ] beide dieser Antworten
+
+[Angular - Formulare](https://angular.io/guide/forms)
+
+#### F75. Was ist der erwartete DOM-Code für diese Verwendung des ngClass-Attribut-Direktivs, wenn isActive true ist?
+
+```html
+<div [ngClass]="{ 'active-item': isActive }">Element Eins</div>
+```
+
+- [ ] `<div active-item>Element Eins</div>`
+- [x] `<div class="active-item">Element Eins</div>`
+- [ ] `<div class="is-active">Element Eins</div>`
+- [ ] `<div class="active-item isActive">Element Eins</div>`
+
+[Angular - NgClass](https://angular.io/api/common/NgClass)
+
+#### F76. Welche Antwort erklärt am besten die Verwendung von ngModel in diesem Template-Code?
+
+```html
+<input [(ngModel)]="user.name" />
+```
+
+- [ ] Es zeigt das Eingabeelement bedingt an, wenn die user.name-Eigenschaft einen Wert hat.
+- [x] Es ist die bidirektionale Datenbindungs-Syntax. Die value-Eigenschaft des Eingabeelements wird an die user.name-Eigenschaft gebunden, und das Wertänderungs-Event für das Formularelement aktualisiert den user.name-Eigenschaftswert.
+- [ ] Es gibt einen Tippfehler im Code. Es sollte nur die eckigen Klammern haben.
+- [ ] Es bindet den Wert der user.name-Eigenschaft an die val-Eigenschaft des Eingabeelements, um seinen Anfangswert zu setzen.
+
+[Angular - NgModel](https://angular.io/api/forms/NgModel)
+
+#### F77. NgModules können innerhalb anderer NgModules enthalten sein. Welches Code-Beispiel sollten Sie verwenden, um TableModule in SharedModule einzuschließen?
+
+- [ ] @NgModule({
+      exports: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [x] @NgModule({
+      imports: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [ ] @NgModule({
+      declarations: [TableModule]
+      })
+      export class SharedModule {}
+
+text
+
+- [ ] @NgModule({
+      providers: [TableModule]
+      })
+      export class SharedModule {}
+
+#### F78. Welche andere Template-Syntax (die die ngClass-Direktive ersetzt) kann verwendet werden, um die CSS-Klassennamen in diesem Markup hinzuzufügen oder zu entfernen?
+
+```html
+<span [ngClass]="{ 'active': isActive, 'can-toggle': canToggle }"> Beschäftigt </span>
+```
+
+- [ ] A
+
+  ```html
+  <span class="{{ isActive ? 'is-active' : '' }} {{ canToggle ? 'can-toggle' : '' }}">
+    Beschäftigt
+  </span>
+  ```
+
+- [x] B
+
+  ```html
+  <span [class.active]="isActive" [class.can-toggle]="canToggle"> Beschäftigt </span>
+  ```
+
+- [ ] C
+
+  ```html
+  <span [styles.class.active]="isActive" [styles.class.can-toggle]="canToggle">
+    Beschäftigt
+  </span>
+  ```
+
+- [ ] D
+
+  ```html
+  <span [css.class.active]="isActive" [css.class.can-toggle]="canToggle"> Beschäftigt </span>
+  ```
+
+#### F79. In diesem Direktiven-Dekorator-Beispiel, was ist der Zweck der multi-Eigenschaft im Provider-Objekt-Literal?
+
+```ts
+@Directive({
+  selector: '[customValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CustomValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class CustomValidatorDirective implements Validator {}
+```
+
+- [ ] Es zeigt an, dass die CustomValidatorDirective auf mehreren Formularelement-Typen verwendet werden kann.
+- [ ] Es erlaubt die Instanziierung mehrerer Instanzen der CustomValidatorDirective. Ohne multi wäre die CustomValidatorDirective ein Singleton für die gesamte App.
+- [x] Es erlaubt die Registrierung verschiedener Provider für das einzelne NG_VALIDATORS-Token. In diesem Fall wird die CustomValidatorDirective zur Liste der verfügbaren Formular-Validatoren hinzugefügt.
+- [ ] Es zeigt an, dass es mehrere Klassen geben wird, die die Logik-Implementierung für den benutzerdefinierten Validator handhaben.
+
+[StackOverflow](https://stackoverflow.com/questions/38144641/what-is-multi-provider-in-angular2)
+
+#### F80. Welchen Angular CLI-Befehl würden Sie verwenden, um Ihre Unit-Tests in einem Prozess auszuführen, der Ihre Test-Suite bei Dateiänderungen erneut ausführt?
+
+- [ ] ng test --single-run=false
+- [ ] ng test --watch-files
+- [ ] ng test --progress
+- [x] ng test
+
+#### F81. Was ist die häufigste Verwendung für den ngOnDestory-Lifecycle-Hook?
+
+- [ ] Entfernen von DOM-Elementen aus der Ansicht der Komponente
+- [ ] Löschen von injizierten Services
+- [x] Abmelden von Observables und Trennen
+- [ ] Alle oben genannten
+
+#### F82. Welche NgModule-Dekorator-Metadaten-Eigenschaft wird genutzt, um anderen zu erlauben...?
+
+- [ ] public
+- [ ] experts
+- [ ] Shared
+- [x] declarations
+
+#### F83. Mit der folgenden Komponentenklasse, welche Template-Syntax würden Sie im Template verwenden, um das Ergebnis des Aufrufs der currentYear-Klassenfunktion anzuzeigen?
+
+```ts
+@Component({
+  selector: 'app-date-card',
+  template: '',
+})
+export class DateCardComponent {
+  currentYear() {
+    return new Date().getFullYear();
+  }
+}
+```
+
+- [x] `{% raw %}{{ currentYear() }}{% endraw %}`
+- [ ] `{% raw %}{{ component.currentYear() }}{% endraw %}`
+- [ ] `{% raw %}{{ currentYear }}{% endraw %}`
+- [ ] Klassenfunktionen können nicht aus der Template-Syntax aufgerufen werden.

--- a/angular/angular-quiz-hi.md
+++ b/angular/angular-quiz-hi.md
@@ -1,0 +1,1342 @@
+## Angular
+
+#### प्र1. इस कंपोनेंट क्लास में ViewChild डेकोरेटर का उद्देश्य क्या है?
+
+```ts
+@Component({
+    ...
+    template: '<p #bio></p>'
+})
+export class UserDetailsComponent {
+    @ViewChild('bio') bio;
+}
+```
+
+- [x] यह कंपोनेंट क्लास के भीतर से `<p>` टैग के लिए ElementRef ऑब्जेक्ट तक पहुंच प्रदान करता है जिसमें कंपोनेंट के टेम्पलेट व्यू में bio टेम्पलेट संदर्भ चर है।
+- [ ] यह इंगित करता है कि `<p>` टैग को पैरेंट व्यू के चाइल्ड के रूप में रेंडर किया गया है जो इस कंपोनेंट का उपयोग करता है।
+- [ ] यह टेम्पलेट में `<p>` टैग को कंटेंट प्रोजेक्शन का समर्थन करता है।
+- [ ] यह अंतिम रेंडर में `<p>` टैग को दृश्यमान बनाता है। यदि #bio का उपयोग टेम्पलेट में किया गया था और @ViewChild का उपयोग क्लास में नहीं किया गया था, तो Angular स्वचालित रूप से `<p>` टैग को छुपा देगा जिस पर #bio है।
+
+#### प्र2. रिएक्टिव फॉर्म्स में FormControl को नेटिव DOM इनपुट एलिमेंट से वायर करने के लिए किस विधि का उपयोग किया जाता है?
+
+- [ ] FormControl को दिए गए स्ट्रिंग नाम को `<form>` एलिमेंट पर controls नामक एट्रिब्यूट में जोड़ें ताकि यह संकेत मिल सके कि इसमें कौन से फ़ील्ड शामिल होने चाहिए।
+- [ ] DOM एलिमेंट पर value एट्रिब्यूट के चारों ओर वर्ग कोष्ठक बाइंडिंग सिंटैक्स का उपयोग करें और इसे FormControl के इंस्टेंस के बराबर सेट करें।
+- [x] formControlName डायरेक्टिव का उपयोग करें और FormControl को दिए गए स्ट्रिंग नाम के बराबर मान सेट करें।
+- [ ] FormControl को दिए गए स्ट्रिंग नाम का उपयोग DOM एलिमेंट id एट्रिब्यूट के मान के रूप में करें।
+
+#### प्र3. `ActivatedRoute` क्लास पर `paramMap` और `queryParamMap` में क्या अंतर है?
+
+- [ ] paramMap एक रूट के URL पथ में पैरामीटर का ऑब्जेक्ट लिटरल है। queryParamMap उन्हीं पैरामीटर का एक Observable है।
+- [ ] paramMap एक Observable है जिसमें एक रूट के URL पथ का हिस्सा बनने वाले पैरामीटर मान होते हैं। queryParamMap एक विधि है जो कुंजियों की एक सरणी लेती है और paramMap में विशिष्ट पैरामीटर खोजने के लिए उपयोग की जाती है।
+- [ ] paramMap Angular 3 से विरासत का नाम है। नया नाम queryParamMap है।
+- [x] दोनों अनुरोधित रूट के URL स्ट्रिंग से मान युक्त Observables हैं। paramMap में URL पथ में पैरामीटर मान होते हैं और queryParamMap में URL क्वेरी पैरामीटर होते हैं।
+
+#### प्र4. async पाइप के निम्नलिखित उपयोग के आधार पर, और मान लें कि users क्लास फ़ील्ड एक Observable है, users Observable में कितनी सदस्यताएं बनाई जा रही हैं?
+
+```html
+<h2>नाम</h2>
+<div *ngFor="let user of users | async">{{ user.name }}</div>
+<h2>उम्र</h2>
+<div *ngFor="let user of users | async">{{ user.age }}</div>
+<h2>लिंग</h2>
+<div *ngFor="let user of users | async">{{ user.gender }}</div>
+```
+
+- [ ] कोई नहीं। async पाइप स्वचालित रूप से सदस्यता नहीं लेता है।
+- [ ] कोई नहीं। टेम्पलेट सिंटैक्स सही नहीं है।
+- [x] तीन। प्रत्येक async पाइप के लिए एक है।
+- [ ] एक। async पाइप आंतरिक रूप से प्रकार द्वारा Observables को कैश करता है।
+
+#### प्र5. आप इस OrderService में addOrder फ़ंक्शन के भीतर से एक एंडपॉइंट पर POST अनुरोध भेजने के लिए HttpClient का उपयोग कैसे कर सकते हैं?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  addOrder(order: Order) {
+    // लापता लाइन
+  }
+}
+```
+
+- [ ] `this.httpClient.url(this.orderUrl).post(order);`
+- [ ] `this.httpClient.send(this.orderUrl, order);`
+- [ ] `this.httpClient.post<Order>(this.orderUrl, order);`
+- [x] `this.httpClient.post<Order>(this.orderUrl, order).subscribe();`
+
+#### प्र6. RouterModule.forRoot विधि का उपयोग किसके लिए किया जाता है?
+
+- [ ] किसी भी प्रोवाइडर को पंजीकृत करना जिसका आप रूटेड कंपोनेंट्स में उपयोग करना चाहते हैं।
+- [x] रूट एप्लिकेशन स्तर पर रूट परिभाषाओं को पंजीकृत करना।
+- [ ] यह इंगित करना कि Angular को आपके रूट को सफल होने के लिए प्रोत्साहित करना चाहिए।
+- [ ] यह घोषणा करना कि आप केवल रूट स्तर पर रूटिंग का उपयोग करना चाहते हैं।
+
+#### प्र7. यह कंपोनेंट मेटाडेटा सिलेक्टर किन DOM एलिमेंट्स से मेल खाएगा?
+
+```ts
+@Component({
+    selector: 'app-user-card',
+    . . .
+})
+```
+
+- [ ] app-user-card एट्रिब्यूट वाला कोई भी एलिमेंट, जैसे `<div app-user-card></div>`।
+- [ ] `<app-user-card></app-user-card>` का पहला इंस्टेंस।
+- [x] `<app-user-card></app-user-card>` के सभी इंस्टेंस।
+- [ ] `<user-card></user-card>` के सभी इंस्टेंस।
+
+#### प्र8. productNames की सूची को रेंडर करने के लिए बिल्ट-इन ngFor स्ट्रक्चरल डायरेक्टिव का उपयोग करने के लिए सही टेम्पलेट सिंटैक्स क्या है?
+
+- [ ] A
+
+  ```html
+  <ul>
+    <li [ngFor]="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] B
+
+  ```html
+  <ul>
+    <li ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [x] C
+
+  ```html
+  <ul>
+    <li *ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] D
+
+  ```html
+  <ul>
+    <? for productName in productNames { ?>
+    <li>{{ productName }}</li>
+    <? } ?>
+  </ul>
+  ```
+
+#### प्र9. कंपोनेंट के लिए CSS स्टाइल सेट करने के लिए उपयोग की जाने वाली दो कंपोनेंट डेकोरेटर मेटाडेटा प्रॉपर्टीज कौन सी हैं?
+
+- [ ] viewEncapsulation और viewEncapsulationFiles।
+- [ ] केवल एक है और यह css नामक प्रॉपर्टी है।
+- [ ] css और cssUrl।
+- [x] styles और styleUrls।
+
+#### प्र10. निम्नलिखित कंपोनेंट क्लास के साथ, टेम्पलेट में title क्लास फ़ील्ड का मान प्रदर्शित करने के लिए आप टेम्पलेट में किस टेम्पलेट सिंटैक्स का उपयोग करेंगे?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '',
+})
+class TitleCardComponent {
+  title = 'User Data';
+}
+```
+
+- [ ] `{{ 'title' }}`
+- [x] `{{ title }}`
+- [ ] `[title]`
+- [ ] टेम्पलेट सिंटैक्स के माध्यम से क्लास फ़ील्ड को टेम्पलेट में प्रदर्शित नहीं किया जा सकता है।
+
+#### प्र11. FormControl पर valueChanges विधि का उद्देश्य क्या है?
+
+- [ ] इसका उपयोग यह कॉन्फ़िगर करने के लिए किया जाता है कि नियंत्रण के लिए कौन से मान की अनुमति है।
+- [ ] इसका उपयोग नियंत्रण के मान को नए मान में बदलने के लिए किया जाता है। आप उस विधि को कॉल करेंगे और फ़ॉर्म फ़ील्ड के लिए नया मान पास करेंगे। यह समय के साथ सेट किए जा सकने वाले मानों की सरणी को पास करने का भी समर्थन करता है।
+- [ ] यह इस बात के आधार पर एक Boolean लौटाता है कि नियंत्रण का मान उस मान से अलग है या नहीं जिसके साथ इसे आरंभ किया गया था।
+- [x] यह एक observable है जो हर बार नियंत्रण का मान बदलता है, तो उत्सर्जित होता है, ताकि आप नए मानों पर प्रतिक्रिया कर सकें और उस समय तर्क निर्णय ले सकें।
+
+#### प्र12. रूटिंग के लिए `<a>` टैग को लिंक करने के लिए किस डायरेक्टिव का उपयोग किया जाता है?
+
+- [ ] routeTo
+- [x] routerLink
+- [ ] routePath
+- [ ] appLink
+
+#### प्र13. इस कंपोनेंट क्लास में Output डेकोरेटर का उपयोग किसके लिए किया जाता है?
+
+```ts
+@Component({
+    selector: 'app-shopping-cart',
+    . . .
+})
+export class ShoppingCartComponent {
+    @Output() itemTotalChanged = new EventEmitter();
+}
+```
+
+- [ ] यह `itemTotalChanged` क्लास फ़ील्ड को सार्वजनिक बनाता है।
+- [ ] यह `itemTotalChanged` क्लास फ़ील्ड में मानों को बाइंड करने का एक तरीका प्रदान करता है, जैसे: `<app-shopping-cart [itemTotalChanged]="newTotal"></app-shopping-cart>`।
+- [x] यह `itemTotalChanged` क्लास फ़ील्ड में इवेंट्स को बाइंड करने का एक तरीका प्रदान करता है, जैसे: `<app-shopping-cart (itemTotalChanged)="logNewTotal($event)"></app-shopping-cart>`।
+- [ ] यह बस दस्तावेज़ीकरण के लिए क्लास फ़ील्ड के सामने टिप्पणी डालने का एक तरीका है।
+
+#### प्र14. सशर्त रूप से प्रदर्शन को संभालने के लिए इन दो मार्कअप उदाहरणों के बीच क्या अंतर है?
+
+```html
+<div *ngIf="isVisible">Active</div>
+<div [hidden]="!isVisible">Active</div>
+```
+
+- [ ] `ngIf` दूसरे उदाहरण के लिए शॉर्टहैंड है। जब Angular उस डायरेक्टिव को प्रोसेस करता है, तो यह hidden प्रॉपर्टी के साथ DOM में एक div एलिमेंट लिखता है।
+- [ ] वे मूल रूप से समान हैं।
+- [x] `ngIf` डायरेक्टिव DOM में div को रेंडर नहीं करता है यदि एक्सप्रेशन false है। `hidden` प्रॉपर्टी उपयोग ब्राउज़र व्यूपोर्ट में div सामग्री को छुपाता है, लेकिन div अभी भी DOM में है।
+- [ ] `ngIf` मान्य है, लेकिन `hidden` प्रॉपर्टी का उपयोग गलत है और एक त्रुटि फेंक देगा।
+
+#### प्र15. इस टेम्पलेट-संचालित फ़ॉर्म उदाहरण में फ़ॉर्म में त्रुटियां होने पर आप सबमिट बटन को कैसे अक्षम कर सकते हैं?
+
+```html
+<form #userForm="ngForm">
+  <input type="text" ngModel name="firstName" required />
+  <input type="text" ngModel name="lastName" required />
+  <button (click)="submit(userForm.value)">Save</button>
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <button (click)="submit(userForm.value)" disable="userForm.invalid">Save</button>
+  ```
+
+- [x] B
+
+  ```html
+  <button (click)="submit(userForm.value)" [disabled]="userForm.invalid">Save</button>
+  ```
+
+- [ ] C
+
+  ```html
+  <button (click)="submit(userForm.value)" [ngForm.disabled]="userForm.valid">Save</button>
+  ```
+
+- [ ] D
+
+  ```html
+  <button (click)="submit(userForm.value)" *ngIf="userForm.valid">Save</button>
+  ```
+
+#### प्र16. यह देखने के लिए कि एक नया contact-card कंपोनेंट बनाने से कौन सी फ़ाइलें जेनरेट होंगी, आप किस Angular CLI कमांड का उपयोग करेंगे?
+
+- [x] ng generate component contact-card --dry-run
+- [ ] ng generate component contact-card --no-files
+- [ ] ng generate component component --dry
+- [ ] ng generate component --exclude
+
+#### प्र17. निम्नलिखित कंपोनेंट के आधार पर, TitleCardComponent के titleText फ़ील्ड को h1 एलिमेंट title प्रॉपर्टी से बाइंड करने के लिए आप किस टेम्पलेट सिंटैक्स का उपयोग करेंगे?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '<h1 title="User Data"> {{titleText}}</h1>',
+})
+export class TitleCardComponent {
+  titleText = 'User Data';
+}
+```
+
+- [ ] `<h1 data-title="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 title="titleText">{{ titleText }}</h1>`
+- [x] `<h1 [title]="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 titleText>{{ titleText }}</h1>`
+
+#### प्र18. Angular लाइफसाइकिल हुक्स क्या हैं?
+
+- [ ] Angular ऐप के स्वास्थ्य को ट्रैक करने के लिए लॉगर
+- [ ] प्रोवाइडर जिनका उपयोग कंपोनेंट्स के इंस्टेंस को ट्रैक करने के लिए किया जा सकता है
+- [ ] बिल्ट-इन पाइप जिनका उपयोग DOM इवेंट्स के लिए टेम्पलेट में किया जा सकता है
+- [x] कंपोनेंट्स और डायरेक्टिव्स के लिए आरक्षित नामित विधियां जिन्हें Angular अपने निष्पादन में सेट समय के दौरान कॉल करेगा, और उन लाइफसाइकिल क्षणों में टैप करने के लिए उपयोग किया जा सकता है
+
+#### प्र19. इस टेम्पलेट सिंटैक्स कोड के लिए सर्वोत्तम विवरण चुनें:
+
+```html
+<span>Boss: {{job?.bossName}} </span>
+```
+
+- [ ] ? async पाइप के लिए शॉर्टहैंड है। job मान एक Observable होना चाहिए।
+- [x] यह job फ़ील्ड पर सुरक्षित नेविगेशन ऑपरेटर (?) का उपयोग कर रहा है। यदि job फ़ील्ड अपरिभाषित है, तो bossName तक पहुंच को अनदेखा किया जाएगा और कोई त्रुटि नहीं होगी।
+- [ ] टेम्पलेट सिंटैक्स में एक त्रुटि है। ? यहाँ मान्य नहीं है।
+- [ ] यह job मान प्रदर्शित कर रहा है यदि इसमें एक है; अन्यथा यह bossName प्रदर्शित कर रहा है।
+
+#### प्र20. आप UserDetailComponent के लिए रूट परिभाषा को कैसे कॉन्फ़िगर करेंगे जो URL पथ user/23 का समर्थन करता है (जहां 23 अनुरोधित उपयोगकर्ता की id का प्रतिनिधित्व करता है)?
+
+- [x] `{ path: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ url: 'user/:id', routedComponent: UserDetailComponent }`
+- [ ] `{ routedPath: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ destination: new UserDetailComponent(), route: 'user/:id' }`
+
+#### प्र21. इस डायरेक्टिव में HostListener डेकोरेटर और HostBinding डेकोरेटर क्या कर रहे हैं?
+
+```ts
+@Directive({
+  selector: '[appCallout]',
+})
+export class CalloutDirective {
+  @HostBinding('style.font-weight') fontWeight = 'normal';
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    this.fontWeight = 'bold';
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.fontWeight = 'normal';
+  }
+}
+```
+
+- [x] वे CalloutDirective.fontWeight फ़ील्ड को इस आधार पर सेट कर रहे हैं कि माउस DOM एलिमेंट पर है या नहीं। HostListener फिर font-weight CSS प्रॉपर्टी को fontWeight मान पर सेट करता है।
+- [ ] वे डायरेक्टिव को DOM एलिमेंट की जांच करने के लिए सेट कर रहे हैं जिस पर यह है। यदि इसमें माउस enter और leave के लिए इवेंट बाइंडिंग जोड़ी गई है तो यह इस कोड का उपयोग करेगा। अन्यथा, कुछ नहीं होगा।
+- [ ] यह HostListener और HostBinding का गलत उपयोग है। HostListener और HostBinding डेकोरेटर डायरेक्टिव्स पर कुछ नहीं करते हैं; वे केवल कंपोनेंट्स पर उपयोग किए जाने पर काम करते हैं।
+- [ ] यदि इस डायरेक्टिव को जिस DOM एलिमेंट पर रखा गया है, उस पर CSS प्रॉपर्टी font-weight सेट है, तो mouseenter और mouseleave इवेंट उठाए जाएंगे।
+
+#### प्र22. टेम्पलेट मार्कअप के भीतर फ़ील्ड मान तक पहुंचने और सत्यापन की जांच करने के लिए इस टेम्पलेट-संचालित फ़ॉर्म फ़ील्ड पर आप किस Angular टेम्पलेट सिंटैक्स का उपयोग कर सकते हैं?
+
+```html
+<input type="text" ngModel name="firstName" required minlength="4" />
+<span *ngIf="">Invalid field data</span>
+```
+
+- [x] आप टेम्पलेट संदर्भ चर और exportAs सुविधा का उपयोग कर सकते हैं जो ngModel डायरेक्टिव में है।
+- [ ] आप इनपुट फ़ील्ड नाम के संयोजन में ngModel डायरेक्टिव का उपयोग कर सकते हैं।
+- [ ] आप HTML इनपुट एलिमेंट के लिए टेम्पलेट संदर्भ चर का उपयोग कर सकते हैं और फिर उसकी valid प्रॉपर्टी की जांच कर सकते हैं।
+- [ ] टेम्पलेट-संचालित फ़ॉर्म के साथ फ़ील्ड मान तक पहुंच प्राप्त करना संभव नहीं है। इसके लिए आपको रिएक्टिव फ़ॉर्म का उपयोग करना होगा।
+
+#### प्र23. इस मार्कअप में headerText टेम्पलेट संदर्भ चर में संग्रहीत होने वाला मान प्रकार क्या है?
+
+```html
+<h1 #headerText>User List</h1>
+```
+
+- [x] एक Angular ElementRef, एक नेटिव एलिमेंट के चारों ओर एक रैपर
+- [ ] `<h1>` एलिमेंट का आंतरिक टेक्स्ट
+- [ ] एक हेडर कंपोनेंट क्लास
+- [ ] HTMLHeadingElement का नेटिव DOM एलिमेंट प्रकार
+
+#### प्र24. इन दो प्रोवाइडर कॉन्फ़िगरेशन के आधार पर परिणामी कोड लॉजिक में क्या अंतर है, यदि कोई है?
+
+```ts
+[{ provide: FormattedLogger, useClass: Logger }][{ provide: FormattedLogger, useExisting: Logger }];
+```
+
+- [ ] वे समान हैं। दोनों Logger के एक नए इंस्टेंस का परिणाम होंगे जो FormattedLogger टोकन से बाउंड है।
+- [x] useClass सिंटैक्स इंजेक्टर को Logger का एक नया इंस्टेंस बनाने और उस इंस्टेंस को FormattedLogger टोकन से बाइंड करने के लिए कहता है। useExisting सिंटैक्स Logger के रूप में घोषित पहले से मौजूद ऑब्जेक्ट इंस्टेंस को संदर्भित करता है।
+- [ ] दोनों गलत हैं। useClass या useExisting के लिए एक strong type का उपयोग नहीं किया जा सकता है।
+- [ ] वे समान हैं। दोनों FormattedLogger टोकन को Logger के इंस्टेंस के लिए एक उपनाम होने का परिणाम होंगे।
+
+#### प्र25. रूट कॉन्फ़िगरेशन में data प्रॉपर्टी (नीचे दिए गए उदाहरण में देखी गई) का उद्देश्य क्या है?
+
+```ts
+   {
+       path: 'customers',
+       component: CustomerListComponent,
+       data: { accountSection: true }
+   }
+```
+
+- [ ] रूटेड कंपोनेंट इंस्टेंस पर @Input मानों को सेट करने के लिए एक key/value मैपिंग
+- [x] रूट से जुड़े स्थिर, केवल-पढ़ने योग्य डेटा को शामिल करने का एक तरीका जिसे ActivatedRoute से पुनर्प्राप्त किया जा सकता है
+- [ ] रूट के लिए गतिशील डेटा लोड करने के लिए उपयोग की जा सकने वाली प्रॉपर्टी
+- [ ] एक ऑब्जेक्ट जो रूटेड कंपोनेंट के constructor में स्वतः इंजेक्ट हो जाएगा।
+
+#### प्र26. बिल्ट-इन `ngIf` स्ट्रक्चरल डायरेक्टिव इस टेम्पलेट सिंटैक्स के आधार पर रेंडर किए गए DOM को कैसे बदलता है?
+
+```ts
+@Component({
+  selector: 'app-product',
+  template: '<div *ngIf="product">{{ product.name }}</div>',
+})
+export class ProductComponent {
+  @Input() product;
+}
+```
+
+- [ ] `<div>` एक प्लेसहोल्डर के रूप में कार्य करता है। यदि product क्लास फ़ील्ड "truthy" है, तो `<div>` को केवल `product.name` मान से बदल दिया जाएगा; यदि नहीं, तो कुछ भी रेंडर नहीं होगा।
+- [ ] `<div>` हमेशा रेंडर होगा, और यदि product फ़ील्ड "truthy" है, तो `<div>` एलिमेंट में `product.name` मान होगा; अन्यथा, यह बिना किसी मान के `<div>` एलिमेंट को रेंडर करेगा।
+- [ ] यह एक त्रुटि उत्पन्न करता है क्योंकि ngIf एक बिल्ट-इन स्ट्रक्चरल डायरेक्टिव नहीं है।
+- [x] यदि product क्लास फ़ील्ड "truthy" है, तो रेंडर किए गए DOM में `product.name` फ़ील्ड के मान के साथ `<div>` शामिल होगा। यदि यह "truthy" नहीं है, तो रेंडर किए गए DOM में `<div>` एलिमेंट नहीं होगा।
+
+#### प्र27. यह कोड क्या पूरा करता है?
+
+```ts
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic().bootstrapModule(AppModule);
+```
+
+- [ ] यह एक NgModule के लिए यूनिट टेस्ट निष्पादित करता है।
+- [ ] यह एक Angular एप्लिकेशन की दस्तावेज़ संरचना को कोड करने का एक तरीका प्रदान करता है। @NgModule इनलाइन कोड टिप्पणी का एक रूप है जो TypeScript कंपाइलर द्वारा अनदेखा किया जाता है लेकिन कोड एडिटर एप्लिकेशन में विशेष फ़ॉर्मेटिंग के साथ दिखाई देगा।
+- [ ] यह AppModule नामक एक Angular मॉड्यूल घोषित करता है और इसे पूरे एप्लिकेशन में lazy loading के लिए उपलब्ध कराता है।
+- [x] यह AppModule नामक एक Angular मॉड्यूल घोषित करता है जिसमें AppComponent नामक एक bootstrapped कंपोनेंट होता है। फिर यह उस मॉड्यूल को Angular के साथ पंजीकृत करता है, ताकि ऐप शुरू हो सके।
+
+#### प्र28. इस रूट कॉन्फ़िगरेशन में _resolve_ प्रॉपर्टी का सबसे अच्छा विवरण कौन सा है?
+
+```ts
+{
+   path: ':id',
+   component: UserComponent,
+   resolve: {
+     user: UserResolverService
+   }
+}
+```
+
+- [x] _UserComponent_ को लोड करने से पहले, राउटर _UserResolverService_ में एक _resolve_ विधि द्वारा लौटाए गए _Observable_ को सदस्यता लेगा। इस तकनीक का उपयोग एक _route_ के लिए प्रीलोडेड डेटा प्राप्त करने के लिए किया जा सकता है।
+- [ ] _route_ को हल करने के बाद, और कंपोनेंट लोड और रेंडर होने के बाद, _UserResolverService_ में _user_ नामक एक विधि चलेगी जो किसी भी खुले डेटा कनेक्शन को साफ करेगी।
+- [ ] एक त्रुटि है। सही प्रॉपर्टी नाम _onResolve_ है।
+- [ ] _UserComponent_ के constructor में _user_ के लिए एक पैरामीटर होगा, और _router_ _UserResolverService_ में एक _user_ विधि को कॉल करके उसके लिए एक मान इंजेक्ट करने को संभालेगा।
+
+#### प्र29. इस कंपोनेंट क्लास में ContentChildren डेकोरेटर का उद्देश्य क्या है?
+
+```ts
+@Component({
+ . . .
+ template: '<ng-content></ng-content>'
+})
+export class TabsListComponent {
+ @ContentChildren(TabComponent) tabs;
+}
+```
+
+- [ ] यदि कोई _TabsComponent_ एलिमेंट _TabsListComponent_ टेम्पलेट में जोड़े जाते हैं, तो वे रनटाइम पर `<ng-content>` एलिमेंट में डाल दिए जाएंगे।
+- [ ] यह _TabsListComponent_ टेम्पलेट में _TabComponent_ कंपोनेंट्स बनाता है जब एक _TabsListComponent_ को instantiate किया जाता है।
+- [x] यह कंपोनेंट क्लास के भीतर से किसी भी _TabComponent_ कंपोनेंट्स तक पहुंच प्रदान करता है जो इस कंपोनेंट के लिए `<ng-content>` में content projected थे।
+- [ ] यह _TabsListComponent_ एलिमेंट में डाले जा सकने वाले अनुमत एलिमेंट्स को केवल _TabComponent_ एलिमेंट्स की अनुमति देने के लिए प्रतिबंधित करता है।
+
+#### प्र30. Angular को एप्लिकेशन में कंपोनेंट्स को प्रोसेस करने के लिए, कंपोनेंट प्रकारों को कहाँ पंजीकृत करने की आवश्यकता है?
+
+- [ ] index.html फ़ाइल में script टैग के भीतर
+- [ ] NgModule डेकोरेटर मेटाडेटा टैग में जिसका नाम _components_ है
+- [ ] कोई पंजीकरण की आवश्यकता नहीं है बस कंपोनेंट फ़ाइलों को ऐप डायरेक्टरी में शामिल करें।
+- [x] NgModule डेकोरेटर मेटाडेटा प्रॉपर्टी में जिसका नाम _declarations_ है
+
+#### प्र31. इस यूनिट टेस्ट में `fixture.detectChanges()` कॉल का उद्देश्य क्या है?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+
+fixture.detectChanges();
+
+expect(fixture.nativeElement.querySelector('h1').textContent).toContain(
+  fixture.componentInstance.title,
+);
+```
+
+- [ ] यह किसी भी संभावित UI परिवर्तन को ट्रैक करता है और यदि कोई बनाया गया है तो यूनिट टेस्ट विफल हो जाएगा।
+- [ ] इसका उपयोग पूरे टेस्ट सूट में कई यूनिट टेस्ट में कंपोनेंट टेम्पलेट स्थिरता सुनिश्चित करने के लिए किया जाता है।
+- [x] यह Angular को परिवर्तन पहचान करने के लिए मजबूर करता है, जो आपके टेम्पलेट को मान्य करने से पहले _UserCardComponent_ को रेंडर करेगा।
+- [ ] इसका उपयोग यूनिट टेस्ट रन के दौरान कंसोल में परिवर्तन-पहचान इवेंट्स को लॉग करने के लिए किया जाता है।
+
+#### प्र32. जब goToUser को मान 15 पास किया जाता है, तो `Router.navigate` विधि की निम्नलिखित कॉल के आधार पर URL सेगमेंट कैसा दिखेगा?
+
+```ts
+export class ToolsComponent {
+  constructor(private router: Router) {}
+  goToUser(id: number) {
+    this.router.navigate(['user', id]);
+  }
+}
+```
+
+- [x] /user/15
+- [ ] /user?id=15
+- [ ] /user:15
+- [ ] /user;id=15
+
+#### प्र33. जब एक सेवा को रूट के लिए प्रदान किया जाता है और lazy-loaded मॉड्यूल के लिए प्रोवाइडर कॉन्फ़िगरेशन में भी जोड़ा जाता है, तो injector lazy-loaded मॉड्यूल में constructors को उस सेवा का कौन सा इंस्टेंस प्रदान करता है?
+
+- [x] जब मॉड्यूल lazy loaded होता है तो उस सेवा का एक नया इंस्टेंस बनाया जाता है।
+- [ ] lazy-loaded मॉड्यूल स्तर पर समान प्रकार की सेवा प्रदान करने की अनुमति नहीं है।
+- [ ] यदि रूट स्तर पर अभी तक सेवा का इंस्टेंस नहीं बनाया गया है, तो यह वहां एक बनाएगा और फिर इसका उपयोग करेगा।
+- [ ] उस सेवा का एक single इंस्टेंस हमेशा रूट पर instantiated होता है और केवल एक ही उपयोग किया जाता है, जिसमें lazy मॉड्यूल के भीतर भी शामिल है।
+
+#### प्र34. इस डायरेक्टिव में HostBinding डेकोरेटर क्या कर रहा है?
+
+```ts
+@Directive({
+  selector: ' [appHighlight] ',
+})
+export class HighlightDirective {
+  @HostBinding('class.highlighted') highlight = true;
+}
+```
+
+- [x] यह किसी भी DOM एलिमेंट में highlighted नामक CSS क्लास जोड़ रहा है जिस पर appHighlight डायरेक्टिव है।
+- [ ] HostBinding डायरेक्टिव्स पर कुछ नहीं करता है, केवल कंपोनेंट्स पर।
+- [ ] यह निर्दिष्ट करता है कि यदि होस्ट एलिमेंट को इसकी class एट्रिब्यूट में highlighted क्लास जोड़ी जाती है, तो डायरेक्टिव क्लास फ़ील्ड highlight को true पर सेट किया जाएगा; और यदि होस्ट पर नहीं जोड़ा गया है तो इसे false पर सेट किया जाएगा।
+- [ ] यह होस्ट एलिमेंट पर एक इनलाइन स्टाइल बना रहा है जिसमें highlight नामक CSS प्रॉपर्टी true पर सेट है।
+
+#### प्र35. रिएक्टिव फॉर्म्स में, नेटिव DOM `<form>` एलिमेंट पर इसे वायर करने के लिए किस Angular फॉर्म क्लास प्रकार का उपयोग किया जाता है?
+
+- [ ] `FormArray`
+- [ ] `FormControl`
+- [x] `FormGroup`
+- [ ] `इन सभी उत्तरों`
+
+#### प्र36. मान लें कि username FormControl को एक minLength validator के साथ कॉन्फ़िगर किया गया है, आप username फ़ील्ड के लिए निम्नलिखित रिएक्टिव फॉर्म मार्कअप में त्रुटि प्रदर्शन कैसे सेट कर सकते हैं?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  ...
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <span *ngIf="username.minLength.invalid"> Username length is not valid </span>
+  ```
+
+- [ ] B
+
+  ```html
+  <input type="text" formControlName="username" [showMinLength]="true" />
+  ```
+
+- [ ] C
+
+  ```html
+  <span *ngIf="form.get('username').getError('minLength') as minLengthError">
+    Username must be at least {{ minLengthError.requiredLength }} characters.
+  </span>
+  ```
+
+- [x] D
+
+  ```html
+  <input type="text" formControlName="username" #userName="ngModel" />
+  <span *ngIf="userName.errors.minlength">
+    Username must be at least {{ userName.errors.minlength.requiredLength }} characters.
+  </span>
+  ```
+
+#### प्र37. एम्युलेटेड व्यू एनकैप्सुलेशन मोड एक कंपोनेंट के लिए CSS को कैसे संभालता है?
+
+- [ ] यह CSS को बिल्कुल वैसे ही रेंडर करता है जैसे आपने इसे बिना किसी बदलाव के लिखा है।
+- [ ] यह shadow DOM मार्कअप और CSS का उपयोग करता है।
+- [x] यह DOM एलिमेंट्स के लिए अद्वितीय एट्रिब्यूट बनाता है और आपके द्वारा लिखे गए CSS सिलेक्टर्स को उन एट्रिब्यूट IDs पर स्कोप करता है।
+- [ ] यह आपके द्वारा लिखे गए सभी CSS नियमों को आपके द्वारा टेम्पलेट में उपयोग किए जाने वाले सभी DOM एलिमेंट्स पर इनलाइन CSS के रूप में रेंडर करता है।
+
+#### प्र38. निम्नलिखित TestBed सेटअप के साथ, UserCardComponent के लिए रेंडर किए गए DOM तक पहुंचने के लिए क्या उपयोग किया जा सकता है?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+```
+
+- [ ] `fixture.componentTemplate`
+- [ ] `fixture.getComponentHtml()`
+- [x] `fixture.nativeElement`
+- [ ] `fixture.componentInstance.template`
+
+#### प्र39. इन दो कंपोनेंट्स को देखते हुए, मार्कअप उपयोग के आधार पर DOM में क्या रेंडर होगा?
+
+```ts
+@Component({
+ selector: 'app-card',
+ template: '<h1>Data Card</h1><ng-content></ng-content>'
+})
+export class CardComponent { }
+
+@Component({
+ selector: 'app-bio',
+ template: '<ng-content></ng-content>.
+})
+export class BioComponent { }
+
+// मार्कअप उपयोग:
+<app-card><app-bio>Been around for four years.</app-bio></app-card>
+```
+
+- [x] A
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+    <app-bio>
+      Been around for four years.
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Data Card</h1>
+  <app-bio> Been around for four years. </app-bio>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+    <ng-content></ng-content>
+    <app-bio>
+      Been around for four years.
+      <ng-content></ng-content>
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <app-card>
+    <h1>Data Card</hl>
+  </app-card>
+  ```
+
+#### प्र40. नीचे दिए गए कोड में app-title-card कंपोनेंट को देखते हुए, app-user-card कंपोनेंट कौन सा DOM रेंडर करेगा?
+
+```ts
+@Component({
+   selector: 'app-user-card',
+   template: '<app-title-card></app-title-card><p>Jenny Smith</p>'
+})
+
+@Component({
+   selector: 'app-title-card',
+   template: '<h1>User Data</hl>'
+})
+
+// पैरेंट कंपोनेंट html में user card कंपोनेंट का उपयोग
+<app-user-card></app-user-card>
+```
+
+- [x] A
+
+  ```html
+  <app-user-card>
+    <app-title-card>
+      <h1>User Data</h1>
+    </app-title-card>
+    <p>Jenny Smith</p>
+  </app-user-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>User Data</h1>
+  <p>Jenny Smith</p>
+  <p></p>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-user-card>
+    <app-title-card></app-title-card>
+  </app-user-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <div app-user-card>
+    <h1 app-title-card>User Data</h1>
+    <p>Jenny Smith</p>
+  </div>
+  ```
+
+#### प्र41. कस्टम प्रोवाइडर पंजीकरण के लिए मेल खाने वाला कोड चुनें जिसे @Inject () डेकोरेटर खोज रहा है:
+
+```ts
+constructor(@Inject('Logger') private logger) { }
+```
+
+- [ ] A
+
+  ```ts
+  providers: [Logger];
+  ```
+
+- [x] B
+
+  ```ts
+  providers: [{ provide: 'Logger', useClass: Logger }];
+  ```
+
+- [ ] C
+
+  ```ts
+  @Injectable({
+      providedln: 'root'
+  })
+  ```
+
+- [ ] D
+
+  ```ts
+  providers: [{ provide: 'Logger' }];
+  ```
+
+#### प्र42. getsettings क्लास विधि में HttpClient.get विधि के निम्नलिखित उपयोग का सर्वोत्तम विवरण कौन सा है?
+
+```ts
+export class SettingsService {
+    constructor(private httpClient: HttpClient) { }
+    ...
+
+getSettings()
+{
+    return this.httpClient.get<Settings>(this.settingsUrl)
+        .pipe(
+            retry(3)
+        );
+}}
+```
+
+- [ ] RxJs pipe विधि subscribe विधि के लिए एक उपनाम है, इसलिए `getSettings` के लिए एक कॉल get क्वेरी को निष्पादित करेगी। retry ऑपरेटर का उपयोग pipe कॉल को get क्वेरी को तीन बार retry करने के लिए कहने के लिए किया जाता है।
+- [ ] यह रनटाइम पर एक त्रुटि उत्पन्न करेगा क्योंकि pipe विधि `Httpclient.get` कॉल से उपलब्ध नहीं है।
+- [ ] getSettings विधि के प्रत्येक single कॉल के परिणामस्वरूप Httpclient settingsUrl के लिए कुल तीन get अनुरोध करेगा, जो आदर्श नहीं है क्योंकि हमेशा दो अतिरिक्त कॉल होंगी जिनकी आवश्यकता नहीं है। retry ऑपरेटर का इस तरह से उपयोग नहीं किया जाना चाहिए।
+- [x] जब getSettings विधि के परिणाम की सदस्यता ली जाएगी, तो HTTP GET कॉल की जाएगी; यदि यह विफल होती है, तो यह हार मानने और त्रुटि वापस करने से पहले तीन बार तक retry की जाएगी।
+
+#### प्र43. जब किसी सेवा को एक विधि के माध्यम से अपनी default स्थिति को आरंभ करने के लिए कुछ सेटअप की आवश्यकता होती है, तो आप यह कैसे सुनिश्चित कर सकते हैं कि सेवा को कहीं भी इंजेक्ट करने से पहले उस विधि को invoke किया जाए?
+
+- [ ] उस सेवा विधि के तर्क को सेवा constructor में डालें।
+- [x] रूट AppModule स्तर पर एक factory provider का उपयोग करें जो उस सेवा विधि को कॉल करने के लिए सेवा पर निर्भर करता है।
+- [ ] एप्लिकेशन शुरुआत में यह करना संभव नहीं है; आप इसे केवल कंपोनेंट स्तर पर कर सकते हैं।
+- [ ] वैश्विक स्तर (window scope) पर सेवा का एक इंस्टेंस instantiate करें और फिर उस विधि को कॉल करें।
+
+#### प्र44. TestBed के इस उपयोग का सबसे अच्छा विवरण कौन सा है?
+
+```ts
+const spy = jasmine.createSpyObj('DataService', ['getUsersFromApi']);
+TestBed.configureTestingModule({
+  providers: [UserService, { provide: DataService, useValue: spy }],
+});
+const userService = TestBed.get(UserService);
+```
+
+- [ ] TestBed की आवश्यकता हर बार होती है जब आप Angular provider के लिए यूनिट टेस्ट में spy ऑब्जेक्ट का उपयोग करना चाहते हैं।
+- [ ] TestBed का उपयोग कंपोनेंट के view को टेस्ट करने के लिए किया जा रहा है।
+- [x] TestBed दो प्रोवाइडर के साथ एक NgModule को scaffold करता है और किसी भी dependency injection को संभालता है। यदि कोई Angular क्लास अपने constructor में DataService का अनुरोध करती है, तो TestBed उस constructor में spy इंजेक्ट करेगा।
+- [ ] TestBed टेस्ट रनर को कॉन्फ़िगर कर रहा है ताकि वह इसे केवल अपने providers सरणी में सूचीबद्ध दो प्रोवाइडर के लिए टेस्ट निष्पादित करने के लिए कह सके।
+
+#### प्र45. कंपोनेंट और डायरेक्टिव के बीच प्राथमिक अंतर क्या है?
+
+- [ ] कंपोनेंट एक selector मेटाडेटा प्रॉपर्टी का उपयोग करता है और डायरेक्टिव नहीं करता है।
+- [ ] डायरेक्टिव का उपयोग DOM में कस्टम इवेंट जोड़ने के लिए किया जा सकता है और कंपोनेंट नहीं कर सकता है।
+- [x] कंपोनेंट का एक टेम्पलेट होता है और डायरेक्टिव का नहीं होता है।
+- [ ] डायरेक्टिव केवल नेटिव DOM एलिमेंट्स को लक्षित कर सकता है।
+
+#### प्र46. मार्कअप में डायरेक्टिव उपयोग के दौरान truncate लंबाई को सेट करने की अनुमति देने के लिए आप इस डायरेक्टिव क्लास में क्या जोड़ सकते हैं?
+
+```ts
+@Directive({
+    selector: '[appTruncate]'
+})
+export class TruncateDirective {
+    . . .
+}
+
+// वांछित उपयोग का उदाहरण:
+<p [appTruncate]="10">Some very long text here</p>
+```
+
+- [x] `@Input() appTruncate: number;`
+- [ ] `@Output() appTruncate;`
+- [ ] `constructor(maxLength: number) { }`
+- [ ] `कुछ नहीं। डायरेक्टिव सिलेक्टर का उपयोग डायरेक्टिव में मान पास करने के लिए नहीं किया जा सकता है।`
+
+#### प्र47. आप इस `HttpClient.get` अनुरोध में क्वेरी पैरामीटर कैसे पास कर सकते हैं?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  getOrdersByYear(year: number): Observable<Order[]> {
+    return this.httpClient.get<Order[]>(this.ordersUrl);
+  }
+}
+```
+
+- [ ] A `return this.httpClient.get<Order[]>(this.ordersUrl, {'year': year})`
+- [ ] B `return this.httpClient.get<Order[]>(this.ordersUrl, year)`
+- [x] C
+
+  ```ts
+  const options = { params: new HttpParams().set('year', year) };
+  return this.httpClient.get<Order[]>(this.ordersUrl, options);
+  ```
+
+- [ ] D
+
+  ```ts
+  getOrdersByYear(year: number): Observable<Order[]> {
+      return this.httpClient.addParam('year', year).get<Order[]>(this.ordersUrl, year);
+  }
+  ```
+
+#### प्र48. मान लें कि `DataService` को एप्लिकेशन के लिए प्रोवाइडर में पंजीकृत किया गया है, इस कंपोनेंट के constructor के आधार पर क्या होता है इसका सर्वोत्तम विवरण कौन सा है?
+
+```ts
+@Component({
+    ...
+})
+export class OrderHistoryComponent {
+    constructor(private dataService: DataService) {}
+    ...
+}
+```
+
+- [ ] यह घोषित करता है कि `OrderHistoryComponent` का `DataService` का अपना संस्करण होगा और इसे कभी भी किसी मौजूदा इंस्टेंस का उपयोग नहीं करना चाहिए। इस कोड को पूर्ण और कार्यशील होने के लिए `DataService` को क्लास के भीतर एक private फ़ील्ड के रूप में instantiate करने की आवश्यकता होगी।
+- [x] जब Angular `OrderHistoryComponent` का एक नया इंस्टेंस बनाता है, तो injector कंपोनेंट constructor के पहले तर्क में `DataService` क्लास का एक इंस्टेंस प्रदान करेगा। constructor का `dataService` पैरामीटर इंस्टेंस पर समान नाम के साथ एक private इंस्टेंस फ़ील्ड सेट करने के लिए उपयोग किया जाएगा।
+- [ ] यह केवल कंपोनेंट टेस्टिंग करने का एक तरीका प्रदान करता है; Angular एप्लिकेशन के वास्तविक रन में constructor का कोई उपयोग नहीं है।
+- [ ] यह कस्टम एलिमेंट जिसे कंपोनेंट लक्षित करता है, को `dataService` नामक एक कस्टम प्रॉपर्टी रखने में सक्षम बनाता है जिसका उपयोग मौजूदा `DataService` इंस्टेंस को बाइंड करने के लिए किया जा सकता है।
+
+#### प्र49. `ngIf` डायरेक्टिव का उपयोग करके इस मार्कअप को पूरा करें ताकि एक else केस लागू किया जा सके जो "User is not active" टेक्स्ट प्रदर्शित करेगा:
+
+```html
+<div *ngIf="userIsActive; else inactive">Currently active!</div>
+```
+
+- [ ] A
+
+  ```html
+  <div #inactive>User is not active.</div>
+  ```
+
+- [ ] B
+
+  ```html
+  <div *ngIf="inactive">User is not active.</div>
+  ```
+
+- [ ] C
+
+  ```html
+  <ng-template #else="inactive">
+    <div>User is not active.</div>
+  </ng-template>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-template #inactive>
+    <div>User is not active.</div>
+  </ng-template>
+  ```
+
+#### प्र50. फीचर मॉड्यूल को lazy load करने के लिए रूट परिभाषा के लिए सही सिंटैक्स क्या है?
+
+- [ ] A
+
+  ```ts
+  {
+    path: 'users',
+    lazy: './users/users.module#UsersModule'
+  }
+  ```
+
+- [x] B
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: () => import('./users/users.module').then(m => m.UserModule)
+  }
+  ```
+
+- [ ] C
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: './users/users.module#UsersModule'
+  }
+  ```
+
+- [ ] D
+
+  ```ts
+  {
+    path: 'users',
+    module: UsersModule
+  }
+  ```
+
+#### प्र51. इस रिएक्टिव फॉर्म उदाहरण में validation कैसे सेट अप और कॉन्फ़िगर किया गया है:
+
+```ts
+export class UserFormControl implements OnInit {
+    ...
+    ngOnInit() {
+        this.form = this.formBuilder.group({
+            username: this.formBuilder.control('',
+                [Validators.required, Validators.minLength(5), this.unique]),
+        )};
+    }
+    unique(control: FormControl) {
+        return control.value !== 'admin' ? null: {notUnique: true};
+    }
+}
+```
+
+- [ ] `username` के लिए `FormControl` उन तीन validators को बाहर करने के लिए कॉन्फ़िगर हो रहा है जो इसे उपयोग करने की अनुमति है।
+- [ ] `username` के लिए `FormControl` तीन संभावित validators का उपयोग करने की अनुमति देने के लिए कॉन्फ़िगर हो रहा है: `required, maxLength`, और `unique` नामक एक कस्टम। इन `validators` को सक्षम करने के लिए, मार्कअप में फॉर्म फ़ील्ड पर एक validator डायरेक्टिव रखना होगा।
+- [ ] रिएक्टिव फॉर्म में validation को इस तरह से सेट अप नहीं किया जा सकता है।
+- [x] `username` के लिए `FormControl` तीन validators के साथ कॉन्फ़िगर हो रहा है: Angular से आने वाले `required` और `minLength` validators, और `unique` नामक एक कस्टम validator फ़ंक्शन जो मान की जांच करता है कि यह string `admin` के बराबर नहीं है।
+
+#### प्र52. इस सेवा क्लास पर Injectable डेकोरेटर क्या करता है?
+
+```ts
+@Injectable({
+    providedIn: 'root'
+)}
+export class DataService { }
+```
+
+- [ ] यह सेवा के लिए एक provider पंजीकृत करता है जो केवल रूट मॉड्यूल स्तर पर उपलब्ध है, किसी भी चाइल्ड मॉड्यूल के लिए नहीं।
+- [x] यह रूट एप्लिकेशन injector में सेवा के लिए एक provider पंजीकृत करता है, जो पूरे एप्लिकेशन में इसका एक single इंस्टेंस उपलब्ध कराता है।
+- [ ] यह इसे इस तरह बनाता है कि सेवा को केवल एप्लिकेशन के लिए bootstrapped कंपोनेंट में इंजेक्ट किया जा सकता है।
+- [ ] यह एक compile time नियम सेट करता है जो आपको रूट NgModule की providers मेटाडेटा प्रॉपर्टी में केवल सेवा प्रकार डालने की अनुमति देता है।
+
+#### प्र53. इस कोड के उपयोग का वर्णन करें
+
+```ts
+export interface AppSettings {
+  title: string;
+  version: number;
+}
+export const APP_SETTINGS = new InjectionToken<AppSettings>('app.settings');
+```
+
+- [ ] InjectionToken, InjectionToken constructor कॉल के माध्यम से रूट provider में AppSettings का एक इंस्टेंस जोड़ता है, जो इसे Angular एप्लिकेशन में सभी NgModules, services और components के लिए स्वचालित रूप से उपलब्ध कराता है बिना इसे कहीं भी इंजेक्ट करने की आवश्यकता के।
+- [x] InjectionToken का उपयोग गैर-class dependency के लिए provider token बनाने के लिए किया जाता है। APP_SETTINGS dependency provider प्रकार के लिए एक Object literal को मान के रूप में प्रदान किया जा सकता है जिसे फिर कंपोनेंट्स, services, आदि में इंजेक्ट किया जा सकता है।
+- [ ] InjectionToken का उपयोग AppSettings के लिए एक dynamic डेकोरेटर बनाने के लिए किया जाता है जिसका उपयोग @AppSettings डेकोरेटर के माध्यम से constructor पैरामीटर पर किया जा सकता है।
+- [ ] इस कोड में एक त्रुटि है क्योंकि आप InjectionToken पर generic प्रकार के लिए TypeScript interface का उपयोग नहीं कर सकते हैं
+
+#### प्र54. निम्नलिखित टेम्पलेट-संचालित फॉर्म उदाहरण के लिए, फॉर्म के डेटा को सबमिट करने के लिए click इवेंट में submit विधि को कौन सा तर्क पास किया जा सकता है?
+
+```html
+<form #form="ngForm">
+  <input type="text" ngModel="firstName" /> <input type="text" ngModel="lastName" />
+  <button (click)="submit()">Save</button>
+</form>
+```
+
+- [x] submit(form.value)
+- [ ] submit($event)
+- [ ] submit(ngForm.value)
+- [ ] submit(FirstName, lastName)
+
+#### प्र55. इस router कोड में `prelodingStrategy` प्रॉपर्टी कॉन्फ़िगरेशन का उद्देश्य क्या है?
+
+```ts
+RouterModule.forRoot(
+  ...{
+    preloadingStrategy: PreloadAllModules,
+  },
+);
+```
+
+- [ ] यह व्यक्तिगत रूट को preloading के लिए flag करने का विकल्प सक्षम करता है।
+- [ ] यह रूट के लिए सभी dependencies को preload करता है, जब ऐप पहली बार शुरू होता है तो services के इंस्टेंस बनाता है
+- [ ] यह सुनिश्चित करता है कि सभी modules एक single ऐप मॉड्यूल bundle फ़ाइल में built हों।
+- [x] यह router को तुरंत सभी रूट को लोड करने के लिए कॉन्फ़िगर करता है जिनमें loadChildren प्रॉपर्टी है (रूट जो आमतौर पर अनुरोध किए जाने पर लोड होते हैं)
+
+#### प्र56. इस मार्कअप को लिखने का एक वैकल्पिक तरीका क्या है ताकि क्लास फ़ील्ड `userName` के मान को `h1` एलिमेंट title प्रॉपर्टी से बाइंड किया जा सके?
+
+```html
+<h1 [title]="userName">Current user is {{ userName }}</h1>
+```
+
+- [ ] `title="userName"`
+- [x] `title="{{ userName }}"`
+- [ ] `title="{{ 'userName' }}"`
+- [ ] इसे करने का एकमात्र तरीका वर्ग कोष्ठक का उपयोग करना है।
+
+#### प्र57. इस उदाहरण में `async` पाइप क्या कर रहा है?
+
+```ts
+@Component({
+  selector: 'app-users',
+  template: '<div *ngFor="let user of users | async">{{ user.name }}</div>',
+})
+export class UsersComponent implements OnInit {
+  users;
+  constructor(private httpClient: HttpClient) {}
+  ngOnInit(): void {
+    this.users = this.httpClient.get<{ name: string }>('users');
+  }
+}
+```
+
+- [ ] यह कुछ नहीं कर रहा है क्योंकि async पाइप का उपयोग `ngFor` statement में नहीं किया जा सकता है।
+- [ ] यह `ngFor` iteration को एक साथ कई उपयोगकर्ताओं की सूचियों का समर्थन करने के लिए कॉन्फ़िगर कर रहा है।
+- [x] यह `HttpClient.get` विधि से लौटाए गए observable की सदस्यता ले रहा है और लौटाए गए मान को unwrap कर रहा है ताकि इसे `ngFor` में iterate किया जा सके।
+- [ ] यह `users` फ़ील्ड में सभी उपयोगकर्ताओं को DOM में एक साथ render होने की अनुमति दे रहा है।
+
+#### प्र58. आप इस डायरेक्टिव को इसके selector मान के आधार पर मार्कअप में कैसे उपयोग करेंगे
+
+```ts
+@Directive({  selector: '[appTruncate]'
+})
+export class TruncateDirective{  . . .
+}
+```
+
+- [ ] `html <p data-directive="appTruncate">Some long text </p>`
+- [x] `html <p appTruncate>Some long text</p>`
+- [ ] `html <p app-truncate>Some long text</p>`
+- [ ] `html <app-truncate>Some long text</app-truncate>`
+
+#### प्र59. किस lifecycle hook का उपयोग कंपोनेंट पर उस कंपोनेंट पर सभी @Input मानों में परिवर्तनों की निगरानी के लिए किया जा सकता है?
+
+- [ ] ngOnInit
+- [ ] ngChanges
+- [ ] ngAfterInputChange
+- [x] ngOnChanges
+
+#### प्र60. इस कस्टम पाइप के टेम्पलेट सिंटैक्स उपयोग का एक उदाहरण क्या होगा?
+
+```ts
+@Pipe({ name: 'truncate' })
+export class TruncatePipe implements PipeTransform {
+  transform(value: string, maxLength: number, showEllipsis: boolean) {
+    const newValue = maxLength ? value.substr(0, maxLength) : value;
+    return showEllipsis ? '${newValue}...' : newValue;
+  }
+}
+```
+
+- [ ] `{{ 'some long text' | truncate:10 }}`
+- [x] `{{ 'some long text' | truncate: 10, true }}`
+- [ ] `{{ 'some long text' | truncate }}`
+- [ ] इन सभी उत्तरों
+
+#### प्र61. आप UsersComponent जेनरेट करने और इसे SharedModule (आपके एप्लिकेशन में shared.module.ts फ़ाइल में) में जोड़ने के लिए कौन सा Angular CLI कमांड चलाएंगे?
+
+- [ ] ng generate component --newModule=shared
+- [x] ng generate component users --module=shared
+- [ ] ng generate component users --shared
+- [ ] ng generate component --add=shared
+
+#### प्र62. आप इस मार्कअप को कैसे फिर से लिख सकते हैं ताकि अंतिम DOM render में div container की आवश्यकता न हो
+
+```html
+<div *ngIf="location">
+  <h1>{{ location.name }}</h1>
+  <p>{{ location.description }}</p>
+</div>
+```
+
+- [ ] A
+
+  ```html
+  <div *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+    {{ endNgIf }}
+  </div>
+  ```
+
+- [ ] B
+
+  ```html
+  <ng-template *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-template>
+  ```
+
+- [ ] C
+
+  ```html
+  <div *ngIf="location" [display]=" ' hidden' ">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </div>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-container *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-container>
+  ```
+
+#### प्र63. आप इस एलिमेंट पर inline style width CSS प्रॉपर्टी के लिए tabWidth नामक कंपोनेंट क्लास फ़ील्ड को बाइंड करने के लिए टेम्पलेट सिंटैक्स का उपयोग कैसे कर सकते हैं?
+
+```html
+<div class="tab"></div>
+```
+
+- [ ] `{{ width: tabWidth }}`
+- [ ] `[width]="tabWidth"`
+- [ ] `[inline.width]="tabWidth"`
+- [x] `[style.width.px]="tabWidth"`
+
+#### प्र64. बिना constructor dependencies वाली सेवा को यूनिट टेस्ट करने के लिए कौन सी Angular utilities की आवश्यकता है, यदि कोई है?
+
+- [ ] By.css() helper विधि की आवश्यकता है
+- [ ] सेवा को यूनिट टेस्ट के लिए चलाने के लिए एक text fixture की आवश्यकता है।
+- [ ] कोई नहीं। एक सेवा को स्वयं instantiated और यूनिट टेस्ट किया जा सकता है।
+- [x] सेवा को instantiate करने के लिए TestBed क्लास की आवश्यकता है।
+
+#### प्र65. CanActivate और CanLoad रूट गार्ड्स के बीच क्या अंतर है?
+
+- [ ] CanActivate का उपयोग पहुंच की जांच करने के लिए किया जाता है। CanLoad का उपयोग रूट के लिए डेटा को preload करने के लिए किया जाता है।
+- [ ] CanLoad का उपयोग ऐप startup पर रूट को रूट टेबल में जोड़ने की अनुमति देने या अस्वीकार करने के लिए किया जाता है। CanActivate का उपयोग रूट के अनुरोध किए जाने पर उन तक पहुंच का प्रबंधन करने के लिए किया जाता है।
+- [ ] CanActivate और CanLoad बिल्कुल समान काम करते हैं।
+- [x] CanLoad एक पूरे NgModule को deliver और लोड होने से रोकता है। CanActivate उस NgModule में एक कंपोनेंट तक रूटिंग को रोकता है, लेकिन वह मॉड्यूल अभी भी लोड होता है।
+
+#### प्र66. इस router definition ऑब्जेक्ट में outlet प्रॉपर्टी का उपयोग किसके लिए किया जाता है?
+
+```ts
+{  path: 'document',  component: DocumentComponent,  outlet: 'document-box'
+}
+```
+
+- [ ] यह DOM में `<document-box>` के सभी इंस्टेंस का पता लगाएगा और रूट navigation पर उनमें एक DocumentComponent एलिमेंट insert करेगा।
+- [ ] यह घोषित करता है कि DocumentComponent का उपयोग `<document-box>` एलिमेंट के चाइल्ड के रूप में किया जा सकता है, इसके अलावा रूटेड होने के।
+- [x] इसका उपयोग एक `<router-outlet>` एलिमेंट को लक्षित करने के लिए किया जाता है जिसमें name एट्रिब्यूट string मान से मेल खाता है, जब DocumentComponent को रूट किया जाता है तो वहां render होने के स्थान के रूप में।
+- [ ] यह router के लिए शक्ति का एक स्रोत है। (निश्चित रूप से उत्तर नहीं :P)
+
+#### प्र67. इस टेम्पलेट सिंटैक्स में, हर बार items प्रॉपर्टी बदलती है (जोड़ी गई, से हटाई गई, आदि), ngFor स्ट्रक्चरल डायरेक्टिव loop में सभी DOM एलिमेंट्स के लिए अपना तर्क फिर से चलाता है। इसे अधिक performant बनाने के लिए किस सिंटैक्स का उपयोग किया जा सकता है?
+
+```html
+<div *ngFor="let item of items">{{ item.id }} - {{ item.name }}</div>
+```
+
+- [ ] `*ngFor="let item of items; let uniqueItem"`
+- [ ] `*ngFor="let item of items.distinct()"`
+- [ ] `*ngFor="let item of items: let i = index"`
+- [x] `*ngFor="let item of items; trackBy: trackById"`
+
+#### प्र68. यह Angular CLI कमांड क्या करती है?
+
+```bash
+ng build --configuration=production --progress=false
+```
+
+- [ ] यह Angular एप्लिकेशन को build करती है, build कॉन्फ़िगरेशन को angular.json फ़ाइल में निर्दिष्ट "production" target पर सेट करती है, और progress output को console में log करती है।
+- [ ] यह Angular एप्लिकेशन को build करती है, build कॉन्फ़िगरेशन को angular.json फ़ाइल में निर्दिष्ट "production" target पर सेट करती है, और परिवर्तनों के लिए फ़ाइलों को watching करती है।
+- [ ] यह Angular एप्लिकेशन को build करती है, build कॉन्फ़िगरेशन को angular.json फ़ाइल में निर्दिष्ट "production" target पर सेट करती है, और परिवर्तनों के लिए फ़ाइलों को watching अक्षम करती है।
+- [x] यह Angular एप्लिकेशन को build करती है, build कॉन्फ़िगरेशन को angular.json फ़ाइल में निर्दिष्ट "production" target पर सेट करती है, और progress output को console में रोकती है।
+
+#### प्र69. सेवा क्लासेस को किन डेकोरेटर के माध्यम से providers के रूप में पंजीकृत किया जा सकता है?
+
+- [ ] @Injectable, @NgModule, @Component, और @Directive।
+- [x] केवल @Injectable।
+- [ ] केवल @Injectable और @NgModule।
+- [ ] केवल @Service और @NgModule।
+
+#### प्र70. इस कंपोनेंट क्लास में Input डेकोरेटर का उपयोग किसके लिए किया जाता है?
+
+```ts
+@Component({  selector:'app-product-name',  ...
+})
+export class ProductNameComponent {  @Input() productName: string
+}
+```
+
+- [ ] इसका उपयोग केवल documentation के लिए क्लास फ़ील्ड के सामने टिप्पणी डालने के लिए किया जाता है।
+- [x] यह कंपोनेंट selector का उपयोग करके productName फ़ील्ड में मानों को बाइंड करने का एक तरीका प्रदान करता है।
+- [ ] यह कंपोनेंट टेम्पलेट में स्वचालित रूप से एक `<input type='text' id='productName'>` Dom एलिमेंट जेनरेट करता है।
+- [ ] यह productName इंस्टेंस फ़ील्ड में मानों को बाइंड करने का एक तरीका प्रदान करता है, बिल्कुल नेटिव DOM एलिमेंट प्रॉपर्टी bindings की तरह।
+
+#### प्र71. किस रूट गार्ड का उपयोग रूट तक navigation को मध्यस्थ करने के लिए किया जा सकता है?
+
+- [x] इन सभी उत्तरों।
+- [ ] CanDeactivate।
+- [ ] CanLoad
+- [ ] CanActivate।
+
+#### प्र72. आप injector को क्लास इंस्टेंस को instantiate करने के बजाय एक token के लिए एक मौजूदा ऑब्जेक्ट का उपयोग करने के लिए कैसे कॉन्फ़िगर कर सकते हैं?
+
+- [x] `useValue` provider कॉन्फ़िगरेशन का उपयोग करें और इसे एक मौजूदा ऑब्जेक्ट या एक ऑब्जेक्ट literal के बराबर सेट करें।
+- [ ] यह संभव नहीं है। Providers को केवल class प्रकारों के साथ कॉन्फ़िगर किया जा सकता है।
+- [ ] बस ऑब्जेक्ट इंस्टेंस या literal को provider की सरणी में जोड़ें।
+- [ ] `asValue` provider कॉन्फ़िगरेशन प्रॉपर्टी का उपयोग करें, इसे true पर सेट करें।
+
+#### प्र73. इस रूट परिभाषा के आधार पर, id रूट पैरामीटर को प्राप्त करने के लिए UserDetailComponent constructor में क्या इंजेक्ट किया जा सकता है?
+
+```ts
+{path: 'user/:id', component: UserDetailComponent }
+```
+
+- [x] ActivatedRoute
+- [ ] CurrentRoute
+- [ ] UrlPath
+- [ ] @Inject('id')
+
+#### प्र74. निम्नलिखित रिएक्टिव फॉर्म मार्कअप के साथ, आप onSubmit क्लास विधि को कॉल करने के लिए क्या जोड़ेंगे?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  <button type="submit" [disabled]="form.invalid">Submit</button>
+</form>
+```
+
+- [ ] इनमें से कोई भी उत्तर नहीं
+- [ ] `<button>` एलिमेंट में (click)="onSubmit()" जोड़ें।
+- [x] `<form>` एलिमेंट में (ngSubmit )="onSubmit()" जोड़ें।
+- [ ] इन दोनों उत्तरों
+
+#### प्र75. जब isActive true है तो ngClass एट्रिब्यूट डायरेक्टिव के इस उपयोग के लिए अपेक्षित DOM कोड क्या है?
+
+```html
+<div [ngClass]="{ 'active-item': isActive }">Item One</div>
+```
+
+- [ ] `<div active-item>Item One</div>`
+- [x] `<div class="active-item">Item One</div>`
+- [ ] `<div class="is-active">Item One</div>`
+- [ ] `<div class="active-item isActive">Item One</div>`
+
+#### प्र76. इस टेम्पलेट कोड में ngModel के उपयोग की सबसे अच्छी व्याख्या कौन सी है?
+
+```html
+<input [(ngModel)]="user.name" />
+```
+
+- [ ] यह सशर्त रूप से input एलिमेंट को प्रदर्शित कर रहा है यदि user.name प्रॉपर्टी का मान है।
+- [x] यह two-way data binding सिंटैक्स है। input एलिमेंट value प्रॉपर्टी user.name प्रॉपर्टी से बाउंड होगी, और फॉर्म एलिमेंट के लिए value change इवेंट user.name प्रॉपर्टी मान को अपडेट करेगा।
+- [ ] कोड में एक typo है। इसमें केवल वर्ग कोष्ठक होने चाहिए।
+- [ ] यह user.name प्रॉपर्टी के मान को input एलिमेंट की val प्रॉपर्टी से बाइंड कर रहा है ताकि इसका प्रारंभिक मान सेट किया जा सके।
+
+#### प्र77. NgModules को अन्य NgModules के भीतर शामिल किया जा सकता है। SharedModule में TableModule को शामिल करने के लिए आपको किस कोड सैंपल का उपयोग करना चाहिए?
+
+- [ ] @NgModule({
+      exports: [TableModule]
+      })
+      export class SharedModule {}
+
+- [x] @NgModule({
+      imports: [TableModule]
+      })
+      export class SharedModule {}
+
+- [ ] @NgModule({
+      declarations: [TableModule]
+      })
+      export class SharedModule {}
+
+- [ ] @NgModule({
+      providers: [TableModule]
+      })
+      export class SharedModule {}
+
+#### प्र78. इस मार्कअप में सशर्त रूप से CSS क्लास नाम जोड़ने या हटाने के लिए कौन सा अन्य टेम्पलेट सिंटैक्स (ngClass डायरेक्टिव को बदलते हुए) का उपयोग किया जा सकता है?
+
+```html
+<span [ngClass]="{ 'active': isActive, 'can-toggle': canToggle }"> Employed </span>
+```
+
+- [ ] A
+
+  ```html
+  <span class="{{ isActive ? 'is-active' : '' }} {{ canToggle ? 'can-toggle' : '' }}">
+    Employed
+  </span>
+  ```
+
+- [x] B
+
+  ```html
+  <span [class.active]="isActive" [class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+- [ ] C
+
+  ```html
+  <span [styles.class.active]="isActive" [styles.class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+- [ ] D
+
+  ```html
+  <span [css.class.active]="isActive" [css.class.can-toggle]="canToggle"> Employed </span>
+  ```
+
+#### प्र79. इस डायरेक्टिव डेकोरेटर उदाहरण में, provider ऑब्जेक्ट literal में multi प्रॉपर्टी का उद्देश्य क्या है?
+
+```ts
+@Directive({
+  selector: '[customValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CustomValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class CustomValidatorDirective implements Validator {}
+```
+
+- [ ] यह इंगित करता है कि CustomValidatorDirective का उपयोग कई फॉर्म एलिमेंट प्रकारों पर किया जा सकता है।
+- [ ] यह CustomValidatorDirective के कई इंस्टेंस को instantiated होने की अनुमति देता है। multi के बिना, CustomValidatorDirective पूरे ऐप के लिए एक singleton होगा।
+- [x] यह single NG_VALIDATORS token के लिए विभिन्न providers के पंजीकरण की अनुमति देता है। इस मामले में, यह CustomValidatorDirective को उपलब्ध फॉर्म validators की सूची में जोड़ रहा है।
+- [ ] यह इंगित करता है कि कस्टम validator के लिए तर्क implementation को संभालने वाली कई classes होंगी।
+
+#### प्र80. आप अपने यूनिट टेस्ट को एक ऐसी प्रक्रिया में चलाने के लिए कौन सा Angular CLI कमांड का उपयोग करेंगे जो फ़ाइल परिवर्तनों पर आपके टेस्ट सूट को फिर से चलाता है?
+
+- [ ] ng test --single-run=false
+- [ ] ng test --watch-files
+- [ ] ng test --progress
+- [x] ng test
+
+#### प्र81. ngOnDestory lifecycle hook का सबसे आम उपयोग क्या है?
+
+- [ ] कंपोनेंट के view से dom एलिमेंट्स को हटाना
+- [ ] किसी भी इंजेक्टेड services को डिलीट करना
+- [x] observables से unsubscribe करना और detach करना
+- [ ] उपरोक्त सभी
+
+#### प्र82. किसी रूट कॉन्फ़िगरेशन में data प्रॉपर्टी (नीचे दिए गए उदाहरण में देखी गई) का उपयोग अन्य को अनुमति देने के लिए किस NgModule डेकोरेटर मेटाडेटा प्रॉपर्टी का लाभ उठाया जाता है....?
+
+- [ ] public
+- [ ] experts
+- [ ] Shared
+- [x] declarations
+
+#### प्र83. निम्नलिखित कंपोनेंट क्लास के साथ, टेम्पलेट में currentYear क्लास फ़ंक्शन को कॉल करने के परिणाम को प्रदर्शित करने के लिए आप टेम्पलेट में किस टेम्पलेट सिंटैक्स का उपयोग करेंगे?
+
+```ts
+@Component({
+  selector: 'app-date-card',
+  template: '',
+})
+export class DateCardComponent {
+  currentYear() {
+    return new Date().getFullYear();
+  }
+}
+```
+
+- [x] `{{ currentYear() }}`
+- [ ] `{{ component.currentYear() }}`
+- [ ] `{{ currentYear }}`
+- [ ] टेम्पलेट सिंटैक्स से क्लास फ़ंक्शन को कॉल नहीं किया जा सकता है।
+
+---
+
+## अनुवाद पूर्ण
+यह Angular प्रश्नोत्तरी का हिंदी अनुवाद है। सभी 83 प्रश्न और उनके विकल्प अनुवादित हैं।

--- a/angular/angular-quiz-ua.md
+++ b/angular/angular-quiz-ua.md
@@ -1,0 +1,1495 @@
+# Angular
+
+#### П1. Яке призначення декоратора ViewChild в цьому класі компонента?
+
+```ts
+@Component({
+    ...
+    template: '<p #bio></p>'
+})
+export class UserDetailsComponent {
+    @ViewChild('bio') bio;
+}
+```
+
+- [x] Він надає доступ з класу компонента до об'єкта ElementRef для тегу `<p>`, який має змінну шаблону bio в поданні шаблону компонента.
+- [ ] Він вказує, що тег `<p>` рендериться як дочірній елемент батьківського подання, яке використовує цей компонент.
+- [ ] Він робить тег `<p>` у шаблоні підтримуючим проекцію вмісту.
+- [ ] Він робить тег `<p>` видимим у фінальному рендері. Якщо #bio був використаний у шаблоні, а @ViewChild не був використаний у класі, тоді Angular автоматично приховає тег `<p>`, який має #bio.
+
+[DigitalOcean - viewchild-access-component](https://www.digitalocean.com/community/tutorials/angular-viewchild-access-component)
+
+#### П2. Який метод використовується для підключення FormControl до нативного DOM елемента input у реактивних формах?
+
+- [ ] Додати строкове ім'я, надане FormControl, до атрибута з назвою controls на елементі `<form>`, щоб вказати, які поля він повинен включати.
+- [ ] Використовувати синтаксис прив'язки квадратних дужок навколо атрибута value на DOM елементі та встановити його рівним екземпляру FormControl.
+- [x] Використовувати директиву formControlName та встановити значення рівним строковому імені, наданому FormControl.
+- [ ] Використовувати строкове ім'я, надане FormControl, як значення для атрибута id DOM елемента.
+
+[Angular.io - Reactive Form Groups](https://angular.io/guide/reactive-forms#creating-nested-form-groups)
+
+#### П3. Яка різниця між `paramMap` та `queryParamMap` у класі `ActivatedRoute`?
+
+- [ ] paramMap - це об'єктний літерал параметрів у шляху URL маршруту. queryParamMap - це Observable тих самих параметрів.
+- [ ] paramMap - це Observable, який містить значення параметрів, що є частиною шляху URL маршруту. queryParamMap - це метод, який приймає масив ключів і використовується для пошуку конкретних параметрів у paramMap.
+- [ ] paramMap - це застаріла назва з Angular 3. Нова назва - queryParamMap.
+- [x] Обидва є Observables, що містять значення з рядка URL запитуваного маршруту. paramMap містить значення параметрів, які знаходяться в шляху URL, а queryParamMap містить параметри запиту URL.
+
+[StackOverflow](https://stackoverflow.com/a/49617621)
+
+#### П4. На основі наступного використання async pipe, і припускаючи, що поле класу users є Observable, скільки підписок на Observable users створюється?
+
+```html
+<h2>Імена</h2>
+<div *ngFor="let user of users | async">{{ user.name }}</div>
+<h2>Вік</h2>
+<div *ngFor="let user of users | async">{{ user.age }}</div>
+<h2>Стать</h2>
+<div *ngFor="let user of users | async">{{ user.gender }}</div>
+```
+
+- [ ] Жодної. async pipe не підписується автоматично.
+- [ ] Жодної. Синтаксис шаблону неправильний.
+- [x] Три. По одній для кожного async pipe.
+- [ ] Одна. async pipe кешує Observables за типом внутрішньо.
+
+[UltimateCourses](https://ultimatecourses.com/blog/angular-ngfor-async-pipe)
+
+#### П5. Як ви можете використовувати HttpClient для надсилання POST запиту до endpoint з функції addOrder у цьому OrderService?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  addOrder(order: Order) {
+    // Відсутній рядок
+  }
+}
+```
+
+- [ ] `this.httpClient.url(this.orderUrl).post(order);`
+- [ ] `this.httpClient.send(this.orderUrl, order);`
+- [ ] `this.httpClient.post<Order>(this.orderUrl, order);`
+- [x] `this.httpClient.post<Order>(this.orderUrl, order).subscribe();`
+
+[Angular.io - Sending data to server](https://angular.io/guide/http#sending-data-to-a-server)
+
+#### П6. Для чого використовується метод RouterModule.forRoot?
+
+- [ ] Для реєстрації будь-яких провайдерів, які ви маєте намір використовувати в маршрутизованих компонентах.
+- [x] Для реєстрації визначень маршрутів на кореневому рівні додатку.
+- [ ] Для вказівки, що Angular повинен підтримувати ваші маршрути для успішності.
+- [ ] Для оголошення, що ви маєте намір використовувати маршрутизацію тільки на кореневому рівні.
+
+[O'REILLY](https://www.oreilly.com/library/view/switching-to-angular/9781788620703/c9e90774-0e10-410b-bd20-d3e9e0b8d117.xhtml)
+
+#### П7. Які DOM елементи будуть відповідати цьому селектору метаданих компонента?
+
+```ts
+@Component({
+    selector: 'app-user-card',
+    . . .
+})
+```
+
+- [ ] Будь-який елемент з атрибутом app-user-card, наприклад `<div app-user-card></div>`.
+- [ ] Перший екземпляр `<app-user-card></app-user-card>`.
+- [x] Всі екземпляри `<app-user-card></app-user-card>`.
+- [ ] Всі екземпляри `<user-card></user-card>`.
+
+[Angular.io - Component Metadata](https://angular.io/guide/architecture-components#component-metadata)
+
+#### П8. Який правильний синтаксис шаблону для використання вбудованої структурної директиви ngFor для рендерингу списку productNames?
+
+- [ ] A
+
+  ```html
+  <ul>
+    <li [ngFor]="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] B
+
+  ```html
+  <ul>
+    <li ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [x] C
+
+  ```html
+  <ul>
+    <li *ngFor="let productName of productNames">{{ productName }}</li>
+  </ul>
+  ```
+
+- [ ] D
+
+  ```html
+  <ul>
+    <? for productName in productNames { ?>
+    <li>{{ productName }}</li>
+    <? } ?>
+  </ul>
+  ```
+
+[Angular.io- Structural Directives](https://angular.io/guide/built-in-directives#listing-items-with-ngfor)
+
+#### П9. Які дві властивості метаданих декоратора компонента використовуються для налаштування CSS стилів для компонента?
+
+- [ ] viewEncapsulation та viewEncapsulationFiles.
+- [ ] Є тільки одна, і це властивість з назвою css.
+- [ ] css та cssUrl.
+- [x] styles та styleUrls.
+
+[Angular.io - Component Styles](https://angular.io/guide/component-styles)
+
+#### П10. З наступним класом компонента, який синтаксис шаблону ви б використали в шаблоні для відображення значення поля класу title?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '',
+})
+class TitleCardComponent {
+  title = 'User Data';
+}
+```
+
+- [ ] `{{ 'title' }}`
+- [x] `{{ title }}`
+- [ ] `[title]`
+- [ ] Поле класу не може бути відображене в шаблоні через синтаксис шаблону.
+
+[Angular.io - String Interpolation or Text Interpolation](https://angular.io/guide/interpolation)
+
+#### П11. Яке призначення методу valueChanges на FormControl?
+
+- [ ] Він використовується для налаштування того, які значення дозволені для контролю.
+- [ ] Він використовується для зміни значення контролю на нове значення. Ви б викликали цей метод і передавали нове значення для поля форми. Він навіть підтримує передачу масиву значень, які можна встановити з часом.
+- [ ] Він повертає Boolean на основі того, чи відрізняється значення контролю від значення, з яким він був ініціалізований.
+- [x] Це observable, який випромінює кожного разу, коли значення контролю змінюється, тож ви можете реагувати на нові значення та приймати логічні рішення в цей момент.
+
+[Angular.io - Displaying a from control value](https://angular.io/guide/reactive-forms#displaying-a-form-control-value)
+
+#### П12. Яка директива використовується для прив'язки тегу `<a>` до маршрутизації?
+
+- [ ] routeTo
+- [x] routerLink
+- [ ] routePath
+- [ ] appLink
+
+[Angular.io - RouterLink](https://angular.io/api/router/RouterLink#description)
+
+#### П13. Для чого використовується декоратор Output у цьому класі компонента?
+
+```ts
+@Component({
+    selector: 'app-shopping-cart',
+    . . .
+})
+export class ShoppingCartComponent {
+    @Output() itemTotalChanged = new EventEmitter();
+}
+```
+
+- [ ] Він робить поле класу `itemTotalChanged` публічним.
+- [ ] Він надає спосіб прив'язати значення до поля класу `itemTotalChanged`, наприклад: `<app-shopping-cart [itemTotalChanged]="newTotal"></app-shopping-cart>`.
+- [x] Він надає спосіб прив'язати події до поля класу `itemTotalChanged`, наприклад: `<app-shopping-cart (itemTotalChanged)="logNewTotal($event)"></app-shopping-cart>`.
+- [ ] Це просто спосіб розмістити коментар перед полем класу для документації.
+
+[Angular.io - Sending data to parent component](https://angular.io/guide/inputs-outputs#sending-data-to-a-parent-component)
+
+#### П14. Яка різниця між цими двома прикладами розмітки для умовної обробки відображення?
+
+```html
+<div *ngIf="isVisible">Активний</div>
+<div [hidden]="!isVisible">Активний</div>
+```
+
+- [ ] `ngIf` є скороченням для іншого прикладу. Коли Angular обробляє цю директиву, він записує елемент div у DOM з властивістю hidden.
+- [ ] Вони фундаментально однакові.
+- [x] Директива `ngIf` не рендерить div у DOM, якщо вираз є false. Використання властивості `hidden` приховує вміст div у вікні браузера, але div все ще залишається в DOM.
+- [ ] `ngIf` є правильним, але використання властивості `hidden` є неправильним і викличе помилку.
+
+[StackOverflow](https://stackoverflow.com/a/39778145)
+
+#### П15. Як ви можете вимкнути кнопку submit, коли форма має помилки в цьому прикладі шаблонних форм?
+
+```html
+<form #userForm="ngForm">
+  <input type="text" ngModel name="firstName" required />
+  <input type="text" ngModel name="lastName" required />
+  <button (click)="submit(userForm.value)">Зберегти</button>
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <button (click)="submit(userForm.value)" disable="userForm.invalid">Зберегти</button>
+  ```
+
+- [x] B
+
+  ```html
+  <button (click)="submit(userForm.value)" [disabled]="userForm.invalid">Зберегти</button>
+  ```
+
+- [ ] C
+
+  ```html
+  <button (click)="submit(userForm.value)" [ngForm.disabled]="userForm.valid">Зберегти</button>
+  ```
+
+- [ ] D
+
+  ```html
+  <button (click)="submit(userForm.value)" *ngIf="userForm.valid">Зберегти</button>
+  ```
+
+[Angular.io - Submit the form with ngSubmit](https://angular.io/guide/forms#submit-the-form-with-ngsubmit)
+
+#### П16. Ви хочете побачити, які файли будуть створені під час створення нового компонента contact-card. Яку команду ви б використали?
+
+- [x] ng generate component contact-card --dry-run
+- [ ] ng generate component contact-card --no-files
+- [ ] ng generate component component --dry
+- [ ] ng generate component --exclude
+
+[Angular.io - ng generate options](https://angular.io/cli/generate#options)
+
+#### П17. На основі наступного компонента, який синтаксис шаблону ви б використали для прив'язки поля titleText компонента TitleCardComponent до властивості title елемента h1?
+
+```ts
+@Component({
+  selector: 'app-title-card',
+  template: '<h1 title="User Data"> {{titleText}}</h1>',
+})
+export class TitleCardComponent {
+  titleText = 'User Data';
+}
+```
+
+- [ ] `<h1 data-title="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 title="titleText">{{ titleText }}</h1>`
+- [x] `<h1 [title]="titleText">{{ titleText }}</h1>`
+- [ ] `<h1 titleText>{{ titleText }}</h1>`
+
+[Angular.io - String Interpolation](https://angular.io/guide/interpolation)
+
+#### П18. Що таке хуки життєвого циклу Angular?
+
+- [ ] логери для відстеження стану додатку Angular
+- [ ] провайдери, які можуть використовуватися для відстеження екземплярів компонентів
+- [ ] вбудовані pipe, які можна використовувати в шаблонах для подій DOM
+- [x] зарезервовані іменовані методи для компонентів і директив, які Angular буде викликати в певний час під час виконання, і які можна використовувати для доступу до цих моментів життєвого циклу
+
+[Angular.io - Lifecycle hooks](https://angular.io/guide/lifecycle-hooks)
+
+#### П19. Виберіть найкращий опис для цього коду синтаксису шаблону:
+
+```html
+<span>Керівник: {{job?.bossName}} </span>
+```
+
+- [ ] ? є скороченням для async pipe. Значення job має бути Observable.
+- [x] Він використовує оператор безпечної навігації (?) для поля job. Якщо поле job є undefined, доступ до bossName буде проігноровано і помилка не виникне.
+- [ ] У синтаксисі шаблону є помилка. ? тут недійсний.
+- [ ] Він відображає значення job, якщо воно є; в іншому випадку він відображає bossName.
+
+[StackOverflow](https://stackoverflow.com/a/60182134)
+
+#### П20. Як би ви налаштували визначення маршруту для UserDetailComponent, який підтримує шлях URL user/23 (де 23 представляє id запитуваного користувача)?
+
+- [x] `{ path: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ url: 'user/:id', routedComponent: UserDetailComponent }`
+- [ ] `{ routedPath: 'user/:id', component: UserDetailComponent }`
+- [ ] `{ destination: new UserDetailComponent(), route: 'user/:id' }`
+
+[CodeCraft - Parameterised Routes](https://codecraft.tv/courses/angular/routing/parameterised-routes/#_configuration)
+
+#### П21. Що роблять декоратори HostListener і декоратор HostBinding у цій директиві?
+
+```ts
+@Directive({
+  selector: '[appCallout]',
+})
+export class CalloutDirective {
+  @HostBinding('style.font-weight') fontWeight = 'normal';
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    this.fontWeight = 'bold';
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.fontWeight = 'normal';
+  }
+}
+```
+
+- [x] Вони встановлюють поле CalloutDirective.fontWeight на основі того, чи знаходиться миша над DOM елементом. HostListener потім встановлює CSS властивість font-weight на значення fontWeight.
+- [ ] Вони налаштовують директиву для перевірки DOM елемента, на якому вона знаходиться. Якщо він має прив'язки подій, додані для входу та виходу миші, буде використовуватися цей код. В іншому випадку нічого не відбудеться.
+- [ ] Це неправильне використання HostListener та HostBinding. Декоратори HostListener і HostBinding нічого не роблять на директивах; вони працюють лише при використанні на компонентах.
+- [ ] Якщо DOM елемент, на якому розміщена ця директива, має встановлену CSS властивість font-weight, події mouseenter та mouseleave будуть генеруватися.
+
+[DigitalOcean](https://www.digitalocean.com/community/tutorials/angular-hostbinding-hostlistener)
+
+#### П22. Який синтаксис шаблону Angular ви можете використовувати в цьому полі шаблонної форми для доступу до значення поля та перевірки валідації в розмітці шаблону?
+
+```html
+<input type="text" ngModel name="firstName" required minlength="4" />
+<span *ngIf="">Невірні дані поля</span>
+```
+
+- [x] Ви можете використовувати змінну посилання на шаблон і функцію exportAs, яку має директива ngModel.
+- [ ] Ви можете використовувати директиву ngModel в комбінації з ім'ям поля input.
+- [ ] Ви можете використовувати змінну посилання на шаблон для HTML елемента input, а потім перевірити властивість valid з неї.
+- [ ] Неможливо отримати доступ до значення поля з шаблонними формами. Для цього ви повинні використовувати реактивні форми.
+
+1. [Angular.io -Show and hide validation error ](https://angular.io/guide/forms#show-and-hide-validation-error-messages)
+2. [Medium](https://medium.com/@agoiabeladeyemi/template-driven-forms-in-angular-4a3a5ad960de)
+
+#### П23. Який тип значення буде збережено в змінній посилання на шаблон headerText у цій розмітці?
+
+```html
+<h1 #headerText>Список користувачів</h1>
+```
+
+- [x] Angular ElementRef, обгортка навколо нативного елемента
+- [ ] внутрішній текст елемента `<h1>`
+- [ ] клас компонента заголовка
+- [ ] нативний тип DOM елемента HTMLHeadingElement
+
+[Pluralsight - Template reference variable](https://www.pluralsight.com/guides/how-to-use-template-reference-variables-in-angular)
+
+#### П24. Яка різниця, якщо вона є, у результуючій логіці коду на основі цих двох конфігурацій провайдера?
+
+```ts
+[{ provide: FormattedLogger, useClass: Logger }][{ provide: FormattedLogger, useExisting: Logger }];
+```
+
+- [ ] Вони однакові. Обидва призведуть до нового екземпляра Logger, який прив'язаний до токена FormattedLogger.
+- [x] Синтаксис useClass вказує інжектору створити новий екземпляр Logger і прив'язати цей екземпляр до токена FormattedLogger. Синтаксис useExisting посилається на вже існуючий екземпляр об'єкта, оголошений як Logger.
+- [ ] Обидва неправильні. Строгий тип не може бути використаний для useClass або useExisting.
+- [ ] Вони однакові. Обидва призведуть до того, що токен FormattedLogger буде псевдонімом екземпляра Logger.
+
+1. [Angular.io - Dependency Providers](https://angular.io/guide/dependency-injection-providers#defining-providers)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-providers/)
+
+#### П25. Яке призначення властивості data (яка видна в прикладі нижче) в конфігурації маршруту?
+
+```ts
+   {
+       path: 'customers',
+       component: CustomerListComponent,
+       data: { accountSection: true }
+   }
+```
+
+- [ ] відображення ключ/значення для встановлення значень @Input на екземплярі маршрутизованого компонента
+- [x] спосіб включити статичні, тільки для читання дані, пов'язані з маршрутом, які можна отримати з ActivatedRoute
+- [ ] властивість маршруту, яку можна використовувати для завантаження динамічних даних для маршруту
+- [ ] об'єкт, який буде автоматично впроваджено в конструктор маршрутизованого компонента
+
+1. [TektutorialsHub](https://www.tektutorialshub.com/angular/angular-pass-data-to-route/#:~:text=Angular%20allows%20us%20to%20pass,of%20the%20history%20state%20object)
+2. [StackOverflow](https://stackoverflow.com/a/36835156)
+
+#### П26. Як вбудована структурна директива `ngIf` змінює відрендерений DOM на основі цього синтаксису шаблону?
+
+```ts
+@Component({
+  selector: 'app-product',
+  template: '<div *ngIf="product">{{ product.name }}</div>',
+})
+export class ProductComponent {
+  @Input() product;
+}
+```
+
+- [ ] `<div>` діє як заповнювач. Якщо поле класу product є "truthy", `<div>` буде замінено лише значенням `product.name`; якщо ні, то нічого не буде відрендерено.
+- [ ] `<div>` завжди буде відрендерено, і якщо поле product є "truthy", елемент `<div>` міститиме значення `product.name`; в іншому випадку він відрендерить елемент `<div>` без значення в ньому.
+- [ ] Він створює помилку, оскільки ngIf не є вбудованою структурною директивою.
+- [x] Якщо поле класу product є "truthy", то відрендерений DOM включатиме `<div>` зі значенням поля `product.name`. Якщо воно не є "truthy", відрендерений DOM не міститиме елемент `<div>`.
+
+[Reference (angular.io)](https://angular.io/api/common/NgIf)
+
+#### П27. Що робить цей код?
+
+```ts
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic().bootstrapModule(AppModule);
+```
+
+- [ ] Він виконує модульний тест для NgModule.
+- [ ] Він надає спосіб кодувати структуру документа додатку Angular. @NgModule - це форма вбудованого коментування коду, яка ігнорується компілятором TypeScript, але відображатиметься зі спеціальним форматуванням у додатках редакторів коду.
+- [ ] Він оголошує модуль Angular з назвою AppModule і робить його доступним для ледачого завантаження в усьому додатку.
+- [x] Він оголошує модуль Angular з назвою AppModule, який містить завантажувальний компонент з назвою AppComponent. Потім він реєструє цей модуль в Angular, щоб додаток міг запуститися.
+
+[Angular.io - The basic NgModule](https://angular.io/guide/ngmodules#the-basic-ngmodule)
+
+#### П28. Який варіант найкраще описує, що робить властивість _resolve_ в цій конфігурації маршруту?
+
+```ts
+{
+   path: ':id',
+   component: UserComponent,
+   resolve: {
+     user: UserResolverService
+   }
+}
+```
+
+- [x] Перед завантаженням _UserComponent_, маршрутизатор підпишеться на _Observable_, що повертається методом _resolve_ у _UserResolverService_. Ця техніка може бути використана для отримання попередньо завантажених даних для _маршруту_.
+- [ ] Після того, як _маршрут_ завершить розв'язання, і компонент завантажено та відрендерено, _UserResolverService_ матиме метод з назвою _user_, який виконається для очищення будь-яких відкритих з'єднань даних.
+- [ ] Є помилка. Правильна назва властивості - _onResolve_.
+- [ ] _UserComponent_ матиме параметр у своєму конструкторі для _user_, і _маршрутизатор_ обробить впровадження значення для цього з виклику методу _user_ у _UserResolverService_.
+
+[angular.io](https://angular.io/api/router/Resolve)
+
+#### П29. Яке призначення декоратора ContentChildren у цьому класі компонента?
+
+```ts
+@Component({
+ . . .
+ template: '<ng-content></ng-content>'
+})
+export class TabsListComponent {
+ @ContentChildren(TabComponent) tabs;
+}
+```
+
+- [ ] Якщо будь-які елементи _TabsComponent_ додано до шаблону _TabsListComponent_, вони будуть поміщені в елемент `<ng-content>` під час виконання.
+- [ ] Він створює компоненти _TabComponent_ у шаблоні _TabsListComponent_, коли створюється екземпляр _TabsListComponent_.
+- [x] Він надає доступ з класу компонента до будь-яких компонентів _TabComponent_, які були спроектовані вмістом у `<ng-content>` для цього компонента.
+- [ ] Він обмежує дозволені елементи, які можна помістити в елемент _TabsListComponent_, дозволяючи лише елементи _TabComponent_.
+
+[betterprogramming.pub](https://betterprogramming.pub/understanding-contentchildren-with-an-example-e76ce78968db)
+
+#### П30. Щоб Angular міг обробляти компоненти в додатку, де потрібно зареєструвати типи компонентів?
+
+- [ ] всередині тегу script в файлі index.html
+- [ ] в тегу метаданих декоратора NgModule з назвою _components_
+- [ ] Реєстрація не потрібна, просто включіть файли компонентів у каталог додатку.
+- [x] у властивості метаданих декоратора NgModule з назвою _declarations_
+
+[angular.io](https://angular.io/guide/ngmodule-api#ngmodule-metadata)
+
+#### П31. Яке призначення виклику `fixture.detectChanges()` у цьому модульному тесті?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+
+fixture.detectChanges();
+
+expect(fixture.nativeElement.querySelector('h1').textContent).toContain(
+  fixture.componentInstance.title,
+);
+```
+
+- [ ] Він відстежує будь-які потенційні зміни UI і провалить модульний тест, якщо вони будуть внесені.
+- [ ] Він використовується для забезпечення стабільності шаблону компонента у кількох модульних тестах у всьому тестовому наборі.
+- [x] Він змушує Angular виконати виявлення змін, що відрендерить _UserCardComponent_ перед тим, як ви зможете перевірити його шаблон.
+- [ ] Він використовується для логування подій виявлення змін у консоль під час виконання модульних тестів.
+
+[angular.io](https://angular.io/api/core/testing/ComponentFixture#detectChanges)
+
+#### П32. Як буде виглядати сегмент URL на основі наступного виклику методу `Router.navigate`, коли goToUser передається значення 15?
+
+```ts
+export class ToolsComponent {
+  constructor(private router: Router) {}
+  goToUser(id: number) {
+    this.router.navigate(['user', id]);
+  }
+}
+```
+
+- [x] /user/15
+- [ ] /user?id=15
+- [ ] /user:15
+- [ ] /user;id=15
+
+[angular.io](https://angular.io/api/router/Router#navigate)
+
+#### П33. Коли сервіс надається для root і також додається до конфігурації провайдерів для ледачо завантаженого модуля, який екземпляр цього сервісу інжектор надає конструкторам у ледачо завантаженому модулі?
+
+- [x] Створюється новий екземпляр цього сервісу, коли модуль завантажується ледачо.
+- [ ] Надання сервісу того самого типу на рівні ледачо завантаженого модуля не дозволено.
+- [ ] Якщо екземпляр сервісу ще не був створений на кореневому рівні, він створить його там, а потім використає.
+- [ ] Один екземпляр цього сервісу завжди створюється на root і є єдиним, який коли-небудь використовується, включаючи ледачі модулі.
+
+#### П34. Що робить декоратор HostBinding у цій директиві?
+
+```ts
+@Directive({
+  selector: ' [appHighlight] ',
+})
+export class HighlightDirective {
+  @HostBinding('class.highlighted') highlight = true;
+}
+```
+
+- [x] Він додає CSS клас з назвою highlighted до будь-якого DOM елемента, який має директиву appHighlight.
+- [ ] HostBinding нічого не робить на директивах, лише на компонентах.
+- [ ] Він вказує, що якщо хост-елемент отримає клас highlighted, доданий до його атрибута class, тоді поле класу директиви highlight буде встановлено в true; і якщо воно не буде додано на хості, воно буде встановлено в false.
+- [ ] Він створює вбудований стиль на хост-елементі з CSS властивістю highlight, встановленою в true.
+
+[StackOverflow](https://stackoverflow.com/a/46207423)
+
+#### П35. У реактивних формах, який тип класу форми Angular використовується на нативному DOM елементі `<form>` для його підключення?
+
+- [ ] `FormArray`
+- [ ] `FormControl`
+- [x] `FormGroup`
+- [ ] `всі ці відповіді`
+
+#### П36. Припускаючи, що FormControl username був налаштований з валідатором minLength, як ви можете налаштувати відображення помилки в наступній розмітці реактивних форм для поля username?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  ...
+</form>
+```
+
+- [ ] A
+
+  ```html
+  <span *ngIf="username.minLength.invalid"> Довжина імені користувача недійсна </span>
+  ```
+
+- [ ] B
+
+  ```html
+  <input type="text" formControlName="username" [showMinLength]="true" />
+  ```
+
+- [ ] C
+
+  ```html
+  <span *ngIf="form.get('username').getError('minLength') as minLengthError">
+    Ім'я користувача повинно містити принаймні {{ minLengthError.requiredLength }} символів.
+  </span>
+  ```
+
+- [x] D
+
+  ```html
+  <input type="text" formControlName="username" #userName="ngModel" />
+  <span *ngIf="userName.errors.minlength">
+    Ім'я користувача повинно містити принаймні {{ userName.errors.minlength.requiredLength }} символів.
+  </span>
+  ```
+
+[Codecraft](https://codecraft.tv/courses/angular/forms/template-driven/)
+
+#### П37. Як емульований режим інкапсуляції view обробляє CSS для компонента?
+
+- [ ] Він рендерить CSS точно так, як ви його написали, без будь-яких змін.
+- [ ] Він використовує розмітку та CSS shadow DOM.
+- [x] Він створює унікальні атрибути для DOM елементів і обмежує CSS селектори, які ви пишете, до цих ID атрибутів.
+- [ ] Він рендерить всі CSS правила, які ви пишете, як вбудований CSS на всіх DOM елементах, які ви використовуєте в шаблоні.
+
+[Angular.io](https://angular.io/guide/view-encapsulation#inspecting-generated-css)
+
+#### П38. З наступним налаштуванням TestBed, що можна використовувати для доступу до відрендереного DOM для UserCardComponent?
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [UserCardComponent],
+});
+let fixture = TestBed.createComponent(UserCardComponent);
+```
+
+- [ ] `fixture.componentTemplate`
+- [ ] `fixture.getComponentHtml()`
+- [x] `fixture.nativeElement`
+- [ ] `fixture.componentInstance.template `
+
+1. [StackOverflow](https://stackoverflow.com/a/56504773)
+2. [Angular.io](https://angular.io/guide/testing-components-basics#nativeelement)
+
+#### П39. Враховуючи ці два компоненти, що буде відрендерено в DOM на основі використання розмітки?
+
+```ts
+@Component({
+ selector: 'app-card',
+ template: '<h1>Карта даних</h1><ng-content></ng-content>'
+})
+export class CardComponent { }
+
+@Component({
+ selector: 'app-bio',
+ template: '<ng-content></ng-content>.
+})
+export class BioComponent { }
+
+// використання розмітки:
+<app-card><app-bio>Існує вже чотири роки.</app-bio></app-card>
+```
+
+- [x] A
+
+  ```html
+  <app-card>
+    <h1>Карта даних</h1>
+    <app-bio>
+      Існує вже чотири роки.
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Карта даних</h1>
+  <app-bio> Існує вже чотири роки. </app-bio>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-card>
+    <h1>Карта даних</h1>
+    <ng-content></ng-content>
+    <app-bio>
+      Існує вже чотири роки.
+      <ng-content></ng-content>
+    </app-bio>
+  </app-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <app-card>
+    <h1>Карта даних</h1>
+  </app-card>
+  ```
+
+#### П40. Враховуючи компонент app-title-card у коді нижче, який DOM буде рендерити компонент app-user-card?
+
+```ts
+@Component({
+   selector: 'app-user-card',
+   template: '<app-title-card></app-title-card><p>Дженні Сміт</p>'
+})
+
+@Component({
+   selector: 'app-title-card',
+   template: '<h1>Дані користувача</h1>'
+})
+
+// використання компонента user card в HTML батьківського компонента
+<app-user-card></app-user-card>
+```
+
+- [x] A
+
+  ```html
+  <app-user-card>
+    <app-title-card>
+      <h1>Дані користувача</h1>
+    </app-title-card>
+    <p>Дженні Сміт</p>
+  </app-user-card>
+  ```
+
+- [ ] B
+
+  ```html
+  <h1>Дані користувача</h1>
+  <p>Дженні Сміт</p>
+  <p></p>
+  ```
+
+- [ ] C
+
+  ```html
+  <app-user-card>
+    <app-title-card></app-title-card>
+  </app-user-card>
+  ```
+
+- [ ] D
+
+  ```html
+  <div app-user-card>
+    <h1 app-title-card>Дані користувача</h1>
+    <p>Дженні Сміт</p>
+  </div>
+  ```
+
+#### П41. Виберіть відповідний код для реєстрації користувацького провайдера, який шукає декоратор @Inject():
+
+```ts
+constructor(@Inject('Logger') private logger) { }
+```
+
+- [ ] A
+
+  ```ts
+  providers: [Logger];
+  ```
+
+- [x] B
+
+  ```ts
+  providers: [{ provide: 'Logger', useClass: Logger }];
+  ```
+
+- [ ] C
+
+  ```ts
+  @Injectable({
+      providedln: 'root'
+  })
+  ```
+
+- [ ] D
+
+  ```ts
+  providers: [{ provide: 'Logger' }];
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/37315355)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-injector-injectable-inject/)
+3. [Angular.io - Dependency Injection In Action](https://angular.io/guide/dependency-injection-in-action#supply-a-custom-provider-with-inject)
+
+#### П42. Який варіант найкраще описує наступне використання методу HttpClient.get у методі класу getsettings?
+
+```ts
+export class SettingsService {
+    constructor(private httpClient: HttpClient) { }
+    ...
+
+getSettings()
+{
+    return this.httpClient.get<Settings>(this.settingsUrl)
+        .pipe(
+            retry(3)
+        );
+}}
+```
+
+- [ ] Метод pipe RxJs є псевдонімом для методу subscribe, тому виклик `getSettings` виконає запит get. Оператор retry використовується, щоб вказати виклику pipe повторити запит get тричі.
+- [ ] Він призведе до помилки під час виконання, оскільки метод pipe недоступний після виклику `Httpclient.get`.
+- [ ] Кожен окремий виклик методу getSettings призведе до того, що Httpclient зробить три загальні запити get до settingsUrl, що не ідеально, оскільки завжди будуть два додаткові виклики, які не потрібні. Оператор retry не слід використовувати таким чином.
+- [x] Коли результат методу getSettings буде підписано, буде зроблено HTTP GET запит; якщо він не вдасться, він буде повторено до трьох разів, перш ніж він здасться і поверне помилку.
+
+1. [learnrxjs.io](https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retry)
+2. [dev.to](https://dev.to/gparlakov/how-does-rxjs-retry-work-412p)
+
+#### П43. Коли сервіс вимагає деякого налаштування для ініціалізації його стану за замовчуванням через метод, як ви можете переконатися, що цей метод викликається перед тим, як сервіс впроваджується будь-куди?
+
+- [ ] Помістити логіку цього методу сервісу в конструктор сервісу натомість.
+- [x] Використовувати фабричний провайдер на кореневому рівні AppModule, який залежить від сервісу для виклику цього методу сервісу.
+- [ ] Неможливо зробити це на старті додатку; ви можете зробити це лише на рівні компонента.
+- [ ] Створити екземпляр сервісу на глобальному рівні (область видимості window), а потім викликати цей метод.
+
+1. [Angular.io](https://angular.io/guide/dependency-injection-providers)
+2. [Stackoverflow](https://stackoverflow.com/questions/39803876/how-to-use-factory-provider)
+
+#### П44. Яке твердження найкраще описує це використання TestBed?
+
+```ts
+const spy = jasmine.createSpyObj('DataService', ['getUsersFromApi']);
+TestBed.configureTestingModule({
+  providers: [UserService, { provide: DataService, useValue: spy }],
+});
+const userService = TestBed.get(UserService);
+```
+
+- [ ] TestBed потрібен щоразу, коли ви хочете використовувати об'єкт spy у модульному тесті для провайдера Angular.
+- [ ] TestBed використовується для тестування подання компонента.
+- [x] TestBed створює NgModule з двома провайдерами і обробляє будь-яке впровадження залежностей. Якщо будь-який клас Angular запитує DataService у своєму конструкторі, TestBed впровадить spy у цей конструктор.
+- [ ] TestBed налаштовує test runner, щоб вказати йому виконувати тести лише для двох провайдерів, перелічених у його масиві провайдерів.
+
+#### П45. Яка основна різниця між компонентом і директивою?
+
+- [ ] Компонент використовує властивість метаданих selector, а директива ні.
+- [ ] Директива може використовуватися для додавання користувацьких подій до DOM, а компонент не може.
+- [x] Компонент має шаблон, а директива ні.
+- [ ] Директива може націлюватися лише на нативні DOM елементи.
+
+[StackOverflow](https://stackoverflow.com/a/34616190)
+
+#### П46. Що ви можете додати до цього класу директиви, щоб дозволити встановлення довжини обрізання під час використання директиви в розмітці?
+
+```ts
+@Directive({
+    selector: '[appTruncate]'
+})
+export class TruncateDirective {
+    . . .
+}
+
+// приклад бажаного використання:
+<p [appTruncate]="10">Якийсь дуже довгий текст тут</p>
+```
+
+- [x] `@Input() appTruncate: number;`
+- [ ] `@Output() appTruncate;`
+- [ ] `constructor(maxLength: number) { }`
+- [ ] `Нічого. Селектор директиви не може використовуватися для передачі значень у директиву.`
+
+1. [Angular.io](https://angular.io/guide/attribute-directives#passing-values-into-an-attribute-directive)
+2. [StackOverflow](https://stackoverflow.com/a/46303049)
+
+#### П47. Як ви можете передати параметри запиту до цього запиту `HttpClient.get`?
+
+```ts
+export class OrderService {
+  constructor(private httpClient: HttpClient) {}
+
+  getOrdersByYear(year: number): Observable<Order[]> {
+    return this.httpClient.get<Order[]>(this.ordersUrl);
+  }
+}
+```
+
+- [ ] A `return this.httpClient.get<Order[]>(this.ordersUrl, {'year': year})`
+- [ ] B `return this.httpClient.get<Order[]>(this.ordersUrl, year)`
+- [x] C
+
+  ```ts
+  const options = { params: new HttpParams().set('year', year) };
+  return this.httpClient.get<Order[]>(this.ordersUrl, options);
+  ```
+
+- [ ] D
+
+  ```ts
+  getOrdersByYear(year: number): Observable<Order[]> {
+      return this.httpClient.addParam('year', year).get<Order[]>(this.ordersUrl, year);
+  }
+  ```
+
+1. [StackOverflow](https://stackoverflow.com/a/34475594)
+2. [TektutorialHub](https://www.tektutorialshub.com/angular/angular-pass-url-parameters-query-strings/#httpparams)
+
+#### П48. Припускаючи, що `DataService` був зареєстрований у провайдерах для додатку, яка відповідь найкраще описує, що відбувається на основі конструктора цього компонента?
+
+```ts
+@Component({
+    ...
+})
+export class OrderHistoryComponent {
+    constructor(private dataService: DataService) {}
+    ...
+}
+```
+
+- [ ] Він оголошує, що `OrderHistoryComponent` матиме свою власну версію `DataService` і що він ніколи не повинен використовувати будь-які існуючі екземпляри. `DataService` потрібно було б створити всередині класу як приватне поле, щоб цей код був повним і працюючим.
+- [x] Коли Angular створює новий екземпляр `OrderHistoryComponent`, інжектор надасть екземпляр класу `DataService` першому аргументу конструктора компонента. Параметр `dataService` конструктора буде використано для встановлення приватного поля екземпляра з тією ж назвою на екземплярі.
+- [ ] Він надає спосіб виконувати тестування компонента тільки; конструктор не має використання в фактичному запуску додатку Angular.
+- [ ] Він дозволяє користувацькому елементу, на який націлюється компонент, мати користувацьку властивість з назвою `dataService`, яку можна використовувати для прив'язки існуючого екземпляра `DataService`.
+
+1. [StackOverflow](https://stackoverflow.com/a/49755822)
+2. [Angular.io - Dependency Injection](https://angular.io/guide/dependency-injection)
+
+#### П49. Завершіть цю розмітку, використовуючи директиву `ngIf` для реалізації випадку else, який відобразить текст "Користувач неактивний":
+
+```html
+<div *ngIf="userIsActive; else inactive">Наразі активний!</div>
+```
+
+- [ ] A
+
+  ```html
+  <div #inactive>Користувач неактивний.</div>
+  ```
+
+- [ ] B
+
+  ```html
+  <div *ngIf="inactive">Користувач неактивний.</div>
+  ```
+
+- [ ] C
+
+  ```html
+  <ng-template #else="inactive">
+    <div>Користувач неактивний.</div>
+  </ng-template>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-template #inactive>
+    <div>Користувач неактивний.</div>
+  </ng-template>
+  ```
+
+[Angular.io](https://angular.io/api/common/NgIf)
+
+#### П50. Який правильний синтаксис для визначення маршруту для ледачого завантаження функціонального модуля?
+
+- [ ] A
+
+  ```ts
+  {
+    path: 'users',
+    lazy: './users/users.module#UsersModule'
+  }
+  ```
+
+- [x] B
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: () => import('./users/users.module').then(m => m.UserModule)
+  }
+  ```
+
+- [ ] C
+
+  ```ts
+  {
+    path: 'users',
+    loadChildren: './users/users.module#UsersModule'
+  }
+  ```
+
+- [ ] D
+
+  ```ts
+  {
+    path: 'users',
+    module: UsersModule
+  }
+  ```
+
+[Angular.io - Lazy Loading Modules](https://angular.io/guide/lazy-loading-ngmodules)
+
+#### П51. Опишіть, як налаштована та конфігурована валідація в цьому прикладі реактивних форм:
+
+```ts
+export class UserFormControl implements OnInit {
+    ...
+    ngOnInit() {
+        this.form = this.formBuilder.group({
+            username: this.formBuilder.control('',
+                [Validators.required, Validators.minLength(5), this.unique]),
+        )};
+    }
+    unique(control: FormControl) {
+        return control.value !== 'admin' ? null: {notUnique: true};
+    }
+}
+```
+
+- [ ] `FormControl` для `username` налаштовується на виключення трьох валідаторів з валідаторів, які йому дозволено використовувати.
+- [ ] `FormControl` для `username` налаштовується на дозвіл використання трьох можливих валідаторів: `required, maxLength` та користувацького з назвою `unique`. Щоб увімкнути ці `валідатори`, директиву валідатора потрібно було б помістити на поля форми в розмітці.
+- [ ] Валідацію не можна налаштувати таким чином у реактивних формах.
+- [x] `FormControl` для `username` налаштовується з трьома валідаторами: валідаторами `required` і `minLength`, які надходять від Angular, та користувацькою функцією валідатора з назвою `unique`, яка перевіряє, що значення не дорівнює рядку `admin`.
+
+1. [Angular.io - Form Validation](https://angular.io/guide/form-validation)
+2. [Angular University Blog](https://blog.angular-university.io/angular-custom-validators/)
+
+#### П52. Що робить декоратор Injectable у цьому класі сервісу?
+
+```ts
+@Injectable({
+    providedIn: 'root'
+)}
+export class DataService { }
+```
+
+- [ ] Він реєструє провайдер для сервісу, який доступний лише на рівні кореневого модуля, а не для будь-яких дочірніх модулів.
+- [x] Він реєструє провайдер для сервісу в кореневому інжекторі додатку, роблячи один екземпляр доступним у всьому додатку.
+- [ ] Він робить так, що сервіс може бути впроваджений лише в завантажувальному компоненті для додатку.
+- [ ] Він налаштовує правило часу компіляції, яке дозволяє вам помістити тип сервісу лише у властивість метаданих провайдерів кореневого NgModule.
+
+[Angular.io](https://angular.io/guide/providers#providing-a-service)
+
+#### П53. Опишіть використання цього коду
+
+```ts
+export interface AppSettings {
+  title: string;
+  version: number;
+}
+export const APP_SETTINGS = new InjectionToken<AppSettings>('app.settings');
+```
+
+- [ ] InjectionToken додає екземпляр AppSettings до кореневого провайдера через виклик конструктора InjectionToken, роблячи його автоматично доступним для всіх NgModules, сервісів та компонентів у всьому додатку Angular без необхідності впроваджувати його будь-куди.
+- [x] InjectionToken використовується для створення токена провайдера для залежності, яка не є класом. Об'єктний літерал може бути наданий як значення для типу провайдера залежності APP_SETTINGS, яке потім може бути впроваджено в компоненти, сервіси тощо.
+- [ ] InjectionToken використовується для створення динамічного декоратора для AppSettings, який може використовуватися на параметрах конструктора через декоратор @AppSettings.
+- [ ] Цей код має помилку, оскільки ви не можете використовувати інтерфейс TypeScript для загального типу на InjectionToken
+
+#### П54. Для наступного прикладу шаблонних форм, який аргумент можна передати методу submit у події click для надсилання даних форми?
+
+```html
+<form #form="ngForm">
+  <input type="text" ngModel="firstName" /> <input type="text" ngModel="lastName" />
+  <button (click)="submit()">Зберегти</button>
+</form>
+```
+
+- [x] submit(form.value)
+- [ ] submit($event)
+- [ ] submit(ngForm.value)
+- [ ] submit(FirstName, lastName)
+
+#### П55. Яке призначення властивості конфігурації `prelodingStrategy` у цьому коді маршрутизатора?
+
+```ts
+RouterModule.forRoot(
+  ...{
+    preloadingStrategy: PreloadAllModules,
+  },
+);
+```
+
+- [ ] Він дозволяє опцію позначити окремі маршрути для попереднього завантаження.
+- [ ] Він попередньо завантажує всі залежності для маршрутів, створюючи екземпляри сервісів під час першого запуску додатку
+- [ ] Він гарантує, що всі модулі будуть побудовані в один файл пакету модуля додатку.
+- [x] Він налаштовує маршрутизатор на негайне завантаження всіх маршрутів, які мають властивість loadChildren (маршрути, які зазвичай завантажуються при запиті)
+
+Посилання:
+
+- [Angular Router, PreloadAllModules](https://angular.io/api/router/PreloadAllModules)
+- [Route preloading in Angular](https://web.dev/route-preloading-in-angular/)
+- [Preloading strategy](https://www.tektutorialshub.com/angular/angular-preloading-strategy/)
+- [Custom preloading strategy](https://www.concretepage.com/angular-2/angular-custom-preloading-strategy#Preloading)
+- [Preloading strategy, save loading time](https://medium.com/geekculture/preloading-strategy-in-angularsave-loading-time-ca791074fe28)
+
+#### П56. Який альтернативний спосіб написати цю розмітку для прив'язки значення поля класу `userName` до властивості title елемента `h1`?
+
+```html
+<h1 [title]="userName">Поточний користувач: {{ userName }}</h1>
+```
+
+- [ ] `title="userName"`
+- [x] `title="{{ userName }}"`
+- [ ] `title="{{ 'userName' }}"`
+- [ ] Єдиний спосіб зробити це - використовувати квадратні дужки.
+
+#### П57. Що робить `async` pipe у цьому прикладі?
+
+```ts
+@Component({
+  selector: 'app-users',
+  template: '<div *ngFor="let user of users | async">{{ user.name }}</div>',
+})
+export class UsersComponent implements OnInit {
+  users;
+  constructor(private httpClient: HttpClient) {}
+  ngOnInit(): void {
+    this.users = this.httpClient.get<{ name: string }>('users');
+  }
+}
+```
+
+- [ ] Він нічого не робить, оскільки async pipe не може використовуватися в операторі `ngFor`.
+- [ ] Він налаштовує ітерацію `ngFor` для підтримки кількох списків користувачів одночасно.
+- [x] Він підписується на observable, повернутий з методу `HttpClient.get`, і розгортає повернене значення, щоб його можна було ітерувати в `ngFor`.
+- [ ] Він дозволяє всім користувачам у полі `users` бути відрендереними одночасно в DOM.
+
+#### П58. Як би ви використали цю директиву в розмітці на основі її значення селектора
+
+```ts
+@Directive({  selector: '[appTruncate]'
+})
+export class TruncateDirective{  . . .
+}
+```
+
+- [ ] `html <p data-directive="appTruncate">Якийсь довгий текст </p> `
+- [x] `html <p appTruncate>Якийсь довгий текст</p> `
+- [ ] `html <p app-truncate>Якийсь довгий текст</p> `
+- [ ] `html <app-truncate>Якийсь довгий текст</app-truncate> `
+
+#### П59. Який хук життєвого циклу можна використовувати на компоненті для моніторингу всіх змін значень @Input на цьому компоненті?
+
+- [ ] ngOnInit
+- [ ] ngChanges
+- [ ] ngAfterInputChange
+- [x] ngOnChanges
+
+[How to detect when an @Input() value changes in Angular?](https://stackoverflow.com/a/44686085/1573267)
+
+#### П60. Який би був приклад використання синтаксису шаблону цього користувацького pipe?
+
+```ts
+@Pipe({ name: 'truncate' })
+export class TruncatePipe implements PipeTransform {
+  transform(value: string, maxLength: number, showEllipsis: boolean) {
+    const newValue = maxLength ? value.substr(0, maxLength) : value;
+    return showEllipsis ? '${newValue}...' : newValue;
+  }
+}
+```
+
+- [ ] `{{ 'якийсь довгий текст' | truncate:10 }}`
+- [x] `{{ 'якийсь довгий текст' | truncate: 10, true }}`
+- [ ] `{{ 'якийсь довгий текст' | truncate }}`
+- [ ] всі ці відповіді
+
+[How do I call an Angular 2 pipe with multiple arguments?](https://stackoverflow.com/questions/36816788/how-do-i-call-an-angular-2-pipe-with-multiple-arguments)
+
+#### П61. Яку команду Angular CLI ви б запустили, щоб згенерувати UsersComponent і додати його до SharedModule (у файлі shared.module.ts у вашому додатку)?
+
+- [ ] ng generate component --newModule=shared
+- [x] ng generate component users --module=shared
+- [ ] ng generate component users --shared
+- [ ] ng generate component --add=shared
+
+#### П62. Як ви можете переписати цю розмітку, щоб контейнер div не був потрібен у фінальному рендері DOM
+
+```html
+<div *ngIf="location">
+  <h1>{{ location.name }}</h1>
+  <p>{{ location.description }}</p>
+</div>
+```
+
+- [ ] A
+
+  ```html
+  <div *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+    {{ endNgIf }}
+  </div>
+  ```
+
+- [ ] B
+
+  ```html
+  <ng-template *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-template>
+  ```
+
+- [ ] C
+
+  ```html
+  <div *ngIf="location" [display]=" ' hidden' ">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </div>
+  ```
+
+- [x] D
+
+  ```html
+  <ng-container *ngIf="location">
+    <h1>{{ location.name }}</h1>
+    <p>{{ location.description }}</p>
+  </ng-container>
+  ```
+
+#### П63. Як ви можете використовувати синтаксис шаблону для прив'язки поля класу компонента з назвою tabWidth до вбудованого стилю CSS властивості width на цьому елементі?
+
+```html
+<div class="tab"></div>
+```
+
+- [ ] `{{ width: tabWidth }}`
+- [ ] `[width]="tabWidth"`
+- [ ] `[inline.width]="tabWidth"`
+- [x] `[style.width.px]="tabWidth"`
+
+#### П64. Які утиліти Angular, якщо такі є, потрібні для модульного тестування сервісу без залежностей конструктора?
+
+- [ ] Потрібен допоміжний метод By.css()
+- [ ] Для запуску сервісу для модульного тесту потрібна текстова фікстура.
+- [ ] Жодної. Сервіс може бути створений і протестований самостійно.
+- [x] Клас TestBed потрібен для створення екземпляра сервісу.
+
+[Angular unit tests](https://angular.io/guide/testing-services)
+
+#### П65. Яка різниця між охоронцями маршруту CanActivate і CanLoad?
+
+- [ ] CanActivate використовується для перевірки доступу. CanLoad використовується для попереднього завантаження даних для маршруту.
+- [ ] CanLoad використовується на старті додатку, щоб дозволити або заборонити додавання маршрутів до таблиці маршрутів. CanActivate використовується для управління доступом до маршрутів у момент їх запиту.
+- [ ] CanActivate і CanLoad роблять абсолютно одне й те саме.
+- [x] CanLoad запобігає завантаженню цілого NgModule. CanActivate зупиняє маршрутизацію до компонента в цьому NgModule, але цей модуль все ще завантажується.
+
+[CanActivate vs Canload](https://stackoverflow.com/questions/42026045/difference-between-angulars-canload-and-canactivate)
+
+#### П66. Для чого використовується властивість outlet в цьому об'єкті визначення маршрутизатора?
+
+```ts
+{  path: 'document',  component: DocumentComponent,  outlet: 'document-box'
+}
+```
+
+- [ ] він знайде всі екземпляри `<document-box>` у DOM і вставить елемент DocumentComponent в них при навігації маршруту.
+- [ ] Він оголошує, що DocumentComponent може використовуватися як дочірній елемент до `<document-box>` на додаток до маршрутизації.
+- [x] Він використовується для націлювання на елемент `<router-outlet>` з атрибутом name, що відповідає строковому значенню, як місце для рендерингу DocumentComponent при маршрутизації.
+- [ ] Це джерело живлення для маршрутизатора.
+
+[Angular-outlet](https://angular.io/api/router/RouterOutlet)
+
+#### П67. У цьому синтаксисі шаблону, кожного разу, коли властивість items змінюється (додається, видаляється тощо), структурна директива ngFor повторно запускає свою логіку для всіх DOM елементів у циклі. Який синтаксис можна використовувати, щоб зробити це більш продуктивним?
+
+```html
+<div *ngFor="let item of items">{{ item.id }} - {{ item.name }}</div>
+```
+
+- [ ] `*ngFor="let item of items; let uniqueItem"`
+- [ ] `*ngFor="let item of items.distinct()"`
+- [ ] `*ngFor="let item of items: let i = index"`
+- [x] `*ngFor="let item of items; trackBy: trackById"`
+
+[StackOverflow - How to use `trackBy` with `ngFor`](https://stackoverflow.com/a/58025894)
+
+#### П68. Що робить ця команда Angular CLI?
+
+```bash
+ng build --configuration=production --progress=false
+```
+
+- [ ] Вона збирає додаток Angular, встановлюючи конфігурацію збірки на ціль "production", вказану в файлі angular.json, і логує вивід прогресу в консоль.
+- [ ] Вона збирає додаток Angular, встановлюючи конфігурацію збірки на ціль "production", вказану в файлі angular.json, і спостерігає за змінами файлів.
+- [ ] Вона збирає додаток Angular, встановлюючи конфігурацію збірки на ціль "production", вказану в файлі angular.json, і вимикає спостереження за змінами файлів.
+- [x] Вона збирає додаток Angular, встановлюючи конфігурацію збірки на ціль "production", вказану в файлі angular.json, і запобігає виводу прогресу в консоль.
+
+[Angular documentation - `ng build`](https://angular.io/cli/build)
+
+#### П69. Класи сервісів можуть бути зареєстровані як провайдери через які декоратори?
+
+- [ ] @Injectable, @NgModule, @Component, і @Directive.
+- [x] Лише @Injectable.
+- [ ] Лише @Injectable і @NgModule.
+- [ ] Лише @Service і @NgModule.
+
+#### П70. Для чого використовується декоратор Input у цьому класі компонента?
+
+```ts
+@Component({  selector:'app-product-name',  ...
+})
+export class ProductNameComponent {  @Input() productName: string
+}
+```
+
+- [ ] Він використовується просто для того, щоб помістити коментар перед полем класу для документації.
+- [x] Він надає спосіб прив'язати значення до поля productName, використовуючи селектор компонента.
+- [ ] Він автоматично генерує DOM елемент `<input type='text' id='productName'>` у шаблоні компонента.
+- [ ] Він надає спосіб прив'язати значення до поля екземпляра productName, як і прив'язки властивостей нативних DOM елементів.
+
+[Angular documentation - `Input()`](https://angular.io/guide/inputs-outputs)
+
+#### П71. Який охоронець маршруту можна використовувати для посередництва в навігації до маршруту?
+
+- [x] всі ці відповіді.
+- [ ] CanDeactivate.
+- [ ] CanLoad
+- [ ] CanActivate.
+
+#### П72. Як ви можете налаштувати інжектор для використання існуючого об'єкта для токена замість того, щоб він створював екземпляр класу?
+
+- [x] Використовувати конфігурацію провайдера `useValue` і встановити її рівною існуючому об'єкту або об'єктному літералу.
+- [ ] Це неможливо. Провайдери можуть бути налаштовані лише з типами класів.
+- [ ] Просто додати екземпляр об'єкта або літерал до масиву провайдера.
+- [ ] Використовувати властивість конфігурації провайдера `asValue`, встановивши її в true.
+
+[Configuring dependency providers](https://angular.io/guide/dependency-injection-providers)
+
+#### П73. На основі цього визначення маршруту, що можна впровадити в конструктор UserDetailComponent, щоб отримати параметр маршруту id?
+
+```ts
+{path: 'user/:id', component: UserDetailComponent }
+```
+
+- [x] ActivatedRoute
+- [ ] CurrentRoute
+- [ ] UrlPath
+- [ ] @Inject('id')
+
+[Common Routing Tasks](https://angular.io/guide/router#observable-parammap-and-component-reuse)
+
+#### П74. З наступною розміткою реактивної форми, що б ви додали, щоб підключити виклик методу класу onSubmit?
+
+```html
+<form [formGroup]="form">
+  <input type="text" formControlName="username" />
+  <button type="submit" [disabled]="form.invalid">Надіслати</button>
+</form>
+```
+
+- [ ] жодна з цих відповідей
+- [ ] Додати (click)="onSubmit()" до елемента `<button>`.
+- [x] Додати (ngSubmit)="onSubmit()" до елемента `<form>`.
+- [ ] обидві ці відповіді
+
+[Angular - Forms](https://angular.io/guide/forms)
+
+#### П75. Який очікуваний код DOM для цього використання атрибутної директиви ngClass, коли isActive має значення true?
+
+```html
+<div [ngClass]="{ 'active-item': isActive }">Елемент один</div>
+```
+
+- [ ] `<div active-item>Елемент один</div>`
+- [x] `<div class="active-item">Елемент один</div>`
+- [ ] `<div class="is-active">Елемент один</div>`
+- [ ] `<div class="active-item isActive">Елемент один</div>`
+
+[Angular - NgClass](https://angular.io/api/common/NgClass)
+
+#### П76. Яка відповідь найкраще пояснює використання ngModel в цьому коді шаблону?
+
+```html
+<input [(ngModel)]="user.name" />
+```
+
+- [ ] Він умовно відображає елемент input, якщо властивість user.name має значення.
+- [x] Це синтаксис двостороннього зв'язування даних. Властивість value елемента input буде прив'язана до властивості user.name, а подія зміни значення для елемента форми оновить значення властивості user.name.
+- [ ] У коді є помилка. Він повинен мати лише квадратні дужки.
+- [ ] Він прив'язує значення властивості user.name до властивості val елемента input, щоб встановити його початкове значення.
+
+[Angular - NgModel](https://angular.io/api/forms/NgModel)
+
+#### П77. NgModules можуть бути включені в інші NgModules. Який зразок коду ви повинні використовувати, щоб включити TableModule у SharedModule?
+
+- [ ] A
+
+  ```ts
+  @NgModule({
+    exports: [TableModule]
+  })
+  export class SharedModule {}
+  ```
+
+- [x] B
+
+  ```ts
+  @NgModule({
+    imports: [TableModule]
+  })
+  export class SharedModule {}
+  ```
+
+- [ ] C
+
+  ```ts
+  @NgModule({
+    declarations: [TableModule]
+  })
+  export class SharedModule {}
+  ```
+
+- [ ] D
+
+  ```ts
+  @NgModule({
+    providers: [TableModule]
+  })
+  export class SharedModule {}
+  ```
+
+#### П78. Який інший синтаксис шаблону (що замінює директиву ngClass) можна використовувати для додавання або видалення назв CSS класів у цій розмітці?
+
+```html
+<span [ngClass]="{ 'active': isActive, 'can-toggle': canToggle }"> Зайнятий </span>
+```
+
+- [ ] A
+
+  ```html
+  <span class="{{ isActive ? 'is-active' : '' }} {{ canToggle ? 'can-toggle' : '' }}">
+    Зайнятий
+  </span>
+  ```
+
+- [x] B
+
+  ```html
+  <span [class.active]="isActive" [class.can-toggle]="canToggle"> Зайнятий </span>
+  ```
+
+- [ ] C
+
+  ```html
+  <span [styles.class.active]="isActive" [styles.class.can-toggle]="canToggle"> Зайнятий </span>
+  ```
+
+- [ ] D
+
+  ```html
+  <span [css.class.active]="isActive" [css.class.can-toggle]="canToggle"> Зайнятий </span>
+  ```
+
+#### П79. У цьому прикладі декоратора директиви, яке призначення властивості multi в об'єктному літералі провайдера?
+
+```ts
+@Directive({
+  selector: '[customValidator]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CustomValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class CustomValidatorDirective implements Validator {}
+```
+
+- [ ] Він вказує, що CustomValidatorDirective може використовуватися на кількох типах елементів форми.
+- [ ] Він дозволяє створювати кілька екземплярів CustomValidatorDirective. Без multi, CustomValidatorDirective був би синглтоном для всього додатку.
+- [x] Він дозволяє реєстрацію різних провайдерів для одного токена NG_VALIDATORS. У цьому випадку він додає CustomValidatorDirective до списку доступних валідаторів форм.
+- [ ] Він вказує, що буде кілька класів, які обробляють логіку реалізації для користувацького валідатора.
+
+[StackOverflow](https://stackoverflow.com/questions/38144641/what-is-multi-provider-in-angular2)
+
+#### П80. Яку команду Angular CLI ви б використали для запуску модульних тестів у процесі, який повторно запускає ваш набір тестів при зміні файлів?
+
+- [ ] ng test --single-run=false
+- [ ] ng test --watch-files
+- [ ] ng test --progress
+- [x] ng test
+
+#### П81. Яке найпоширеніше використання для хука життєвого циклу ngOnDestroy?
+
+- [ ] Видалити DOM елементи з подання компонента
+- [ ] Видалити будь-які впроваджені сервіси
+- [x] Відписатися від observables і від'єднати обробники подій
+- [ ] Всі вищезазначені
+
+#### П82. Яка властивість метаданих декоратора NgModule використовується, щоб дозволити іншим модулям використовувати компоненти та директиви?
+
+- [ ] public
+- [x] exports
+- [ ] shared
+- [ ] declarations
+
+#### П83. З наступним класом компонента, який синтаксис шаблону ви б використали в шаблоні для відображення результату виклику функції класу currentYear?
+
+```ts
+@Component({
+  selector: 'app-date-card',
+  template: '',
+})
+export class DateCardComponent {
+  currentYear() {
+    return new Date().getFullYear();
+  }
+}
+```
+
+- [x] `{{ currentYear() }}`
+- [ ] `{{ component.currentYear() }}`
+- [ ] `{{ currentYear }}`
+- [ ] Функції класу не можна викликати з синтаксису шаблону.


### PR DESCRIPTION
## PR Checklist

This PR is ready for review and meets the requirements set out in [Suggestion how to contribute](CONTRIBUTING.md)

## Fixes

Closes #5531 
Closes #5456 
Closes #5097 

### DOD

- [x] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [ ] I have made small correction/improvements

### Changes / Instructions

This PR adds **4 new language translations** for the Android quiz:

**New Files:**
- `angular/angular-quiz-ch.md` - Chinese (中文) translation
- `angular/angular-quiz-de.md` - German (Deutsch) translation
- `angular/angular-quiz-hi.md` - Hindi (हिन्दी) translation  
- `angular/angular-quiz-ua.md` - Ukrainian (Українська) translation

All translations maintain the same question structure and content as the original Angular quiz, making the assessment accessible to Chinese, German, Hindi, and Ukrainian-speaking users.