### PR TITLE
Fix Q69 ambiguous box model question (#6923)

### DIFF
--- a/front-end-development/front-end-development-quiz.md
+++ b/front-end-development/front-end-development-quiz.md
@@ -688,21 +688,21 @@ console.log(currencies);
 - [ ] Set `width: 100%` on the images.
 - [ ] Set `resize: true` on the images.
 
-#### Q69. The CSS box model describes how different parts of a box are calculated. Under the standard box model, what is the total width of the content box plus padding (excluding border and margin) in the following CSS?
+#### Q69. Under the standard CSS box model, what is the total visible width of the element (content + padding + border), excluding margins?
 
 ```css
 box {
   width: 200px;
   padding: 10px;
-  margin: 0 15px;
   border: 2px solid black;
+  margin: 0 15px;
 }
-```
-
-- [ ] 230px
-- [x] 220px 
+ ```md
+- [x] 224px
 - [ ] 200px
+- [ ] 220px
 - [ ] 260px
+
 
 
 #### Q70. How would you round the value 11.354 to the nearest full integer?


### PR DESCRIPTION
Fixes #6923

- Clarified question wording to remove ambiguity around "visible width"
- Corrected border syntax
- Added correct visible width: 224px
- Updated answer choices
<img width="777" height="384" alt="Screenshot 2025-11-25 093006" src="https://github.com/user-attachments/assets/29c617ff-dfbd-40e9-a49b-f09d95b20c27" />
