### PR TITLE
fix: correct spelling typo 'Javascipt' to 'JavaScript'

### DIFF
--- a/reactjs/reactjs-quiz.md
+++ b/reactjs/reactjs-quiz.md
@@ -7,7 +7,7 @@
 
 - [x] Swift.
 - [ ] JSX.
-- [ ] Javascipt.
+- [ ] JavaScript.
 - [ ] TypeScript.
 
 #### Q97. This code is part of an app that collects Pokemon. How would you print the list of the ones collected so far?
@@ -479,7 +479,7 @@ useEffect(callNetworkFunc, XXXX);
 
 - [x] Swift.
 - [ ] JSX.
-- [ ] Javascipt.
+- [ ] JavaScript.
 - [ ] TypeScript.
 
 #### Q136. Which answer best describes a function component?


### PR DESCRIPTION
## Summary
- Fixed typo in reactjs-quiz.md: 'Javascipt.' → 'JavaScript.'
- This typo appeared in both Q96 and Q136 questions

## Changes
- Line 10: corrected 'Javascipt.' to 'JavaScript.'
- Line 482: corrected 'Javascipt.' to 'JavaScript.'

## Test Plan
- [x] Verified no more instances of 'Javascipt' in the file
- [x] Context remains correct (this is an option in a multiple choice question about React)